### PR TITLE
Increase TCP buffer limit. Previously limited to 1024.

### DIFF
--- a/gstd/gstd_tcp.c
+++ b/gstd/gstd_tcp.c
@@ -304,7 +304,7 @@ gstd_tcp_callback (GSocketService * service,
   GInputStream *istream;
   GOutputStream *ostream;
   gint read;
-  const guint size = 1024;
+  const guint size = 1024*1024;
   gchar *output = NULL;
   gchar *response;
   gchar *message;


### PR DESCRIPTION
See https://github.com/RidgeRun/gstd-1.x/issues/10 for more context.