### PR TITLE
Move SIGINT signal registration after parsing command line and text file

### DIFF
--- a/gstd_client/gstd_client.c
+++ b/gstd_client/gstd_client.c
@@ -336,10 +336,6 @@ main (gint argc, gchar * argv[])
     return EXIT_SUCCESS;
   }
 
-  signal (SIGINT, sig_handler);
-  init_readline ();
-  read_history (history_full);
-
   data = (GstdClientData *) g_malloc (sizeof (GstdClientData));
   data->quiet = quiet;
   data->prompt = prompt;
@@ -367,6 +363,10 @@ main (gint argc, gchar * argv[])
   // No readline, no interaction
   quit = TRUE;
 #endif
+
+  signal (SIGINT, sig_handler);
+  init_readline ();
+  read_history (history_full);
 
   gstd_client_header (quiet);
   /* Jump here in case of an interrupt, so we can exit */


### PR DESCRIPTION
gstd-client is unable to exit cleanly when waiting on `bus_read` command when issued without interactive mode.

I moved signal registration after parsing command line and text commands, so ctrl-c works as expected.