### PR TITLE
Add element child properties support

### DIFF
--- a/gstd/gstd_element.c
+++ b/gstd/gstd_element.c
@@ -105,6 +105,8 @@ gstd_element_set_property (GObject *, guint, const GValue *, GParamSpec *);
 static void gstd_element_dispose (GObject *);
 static GstdReturnCode gstd_element_to_string (GstdObject *, gchar **);
 void gstd_element_internal_to_string (GstdElement *, gchar **);
+void gstd_element_properties_to_string (GstdElement * self);
+void gstd_element_signals_to_string (GstdElement * self);
 static GstdReturnCode gstd_element_fill_properties (GstdElement * self);
 static GstdReturnCode gstd_element_fill_signals (GstdElement * self);
 static GType gstd_element_property_get_type (GType g_type);
@@ -298,39 +300,42 @@ gstd_element_to_string (GstdObject * object, gchar ** outstring)
 }
 
 void
-gstd_element_internal_to_string (GstdElement * self, gchar ** outstring)
+gstd_element_properties_to_string (GstdElement * self)
 {
-  GParamSpec **properties;
+  GList *list;
+  GParamSpec *pspec;
   GValue value = G_VALUE_INIT;
   GValue flags = G_VALUE_INIT;
-  GSignalQuery *query = NULL;
-  GList *signal_list;
-
-  gchar *sflags;
-  guint n, i, j;
   const gchar *typename;
+  gchar *sflags;
 
   g_return_if_fail (GSTD_IS_OBJECT (self));
 
-  gstd_iformatter_begin_object (self->formatter);
   gstd_iformatter_set_member_name (self->formatter, "element_properties");
   gstd_iformatter_begin_array (self->formatter);
 
-  properties =
-      g_object_class_list_properties (G_OBJECT_GET_CLASS (self->element), &n);
-  for (i = 0; i < n; i++) {
+  list = self->element_properties->list;
+  while (list) {
+    GstdProperty *property = list->data;
+
+    if (property->pspec)
+      pspec = property->pspec;
+    else
+      pspec =
+          g_object_class_find_property (G_OBJECT_GET_CLASS (property->target),
+          GSTD_OBJECT_NAME (property));
     /* Describe each parameter using a structure */
     gstd_iformatter_begin_object (self->formatter);
 
     gstd_iformatter_set_member_name (self->formatter, "name");
 
-    gstd_iformatter_set_string_value (self->formatter, properties[i]->name);
+    gstd_iformatter_set_string_value (self->formatter,
+        GSTD_OBJECT_NAME (property));
 
-    typename = g_type_name (properties[i]->value_type);
+    typename = g_type_name (pspec->value_type);
 
-    g_value_init (&value, properties[i]->value_type);
-    g_object_get_property (G_OBJECT (self->element), properties[i]->name,
-        &value);
+    g_value_init (&value, pspec->value_type);
+    g_object_get_property (G_OBJECT (property->target), pspec->name, &value);
 
     gstd_iformatter_set_member_name (self->formatter, "value");
     gstd_iformatter_set_value (self->formatter, &value);
@@ -342,12 +347,12 @@ gstd_element_internal_to_string (GstdElement * self, gchar ** outstring)
     g_value_unset (&value);
 
     g_value_init (&flags, GSTD_TYPE_PARAM_FLAGS);
-    g_value_set_flags (&flags, properties[i]->flags);
+    g_value_set_flags (&flags, pspec->flags);
     sflags = g_strdup_value_contents (&flags);
     g_value_unset (&flags);
 
     gstd_iformatter_set_member_name (self->formatter, "description");
-    gstd_iformatter_set_string_value (self->formatter, properties[i]->_blurb);
+    gstd_iformatter_set_string_value (self->formatter, pspec->_blurb);
 
     gstd_iformatter_set_member_name (self->formatter, "type");
     gstd_iformatter_set_string_value (self->formatter, typename);
@@ -362,10 +367,23 @@ gstd_element_internal_to_string (GstdElement * self, gchar ** outstring)
 
     /* Close parameter structure */
     gstd_iformatter_end_object (self->formatter);
+
+    list = list->next;
   }
-  g_free (properties);
 
   gstd_iformatter_end_array (self->formatter);
+
+}
+
+void
+gstd_element_signals_to_string (GstdElement * self)
+{
+  GSignalQuery *query = NULL;
+  GList *signal_list;
+  guint j;
+  const gchar *typename;
+
+  g_return_if_fail (GSTD_IS_OBJECT (self));
 
   gstd_iformatter_set_member_name (self->formatter, "element_signals");
   gstd_iformatter_begin_array (self->formatter);
@@ -401,6 +419,18 @@ gstd_element_internal_to_string (GstdElement * self, gchar ** outstring)
   }
 
   gstd_iformatter_end_array (self->formatter);
+}
+
+void
+gstd_element_internal_to_string (GstdElement * self, gchar ** outstring)
+{
+
+  g_return_if_fail (GSTD_IS_OBJECT (self));
+
+  gstd_iformatter_begin_object (self->formatter);
+
+  gstd_element_properties_to_string (self);
+  gstd_element_signals_to_string (self);
 
   gstd_iformatter_end_object (self->formatter);
 

--- a/gstd/gstd_element.c
+++ b/gstd/gstd_element.c
@@ -443,7 +443,6 @@ gstd_element_append_object_properties (GstObject * object,
     gstd_list_append_child (properties, element_property);
   }
 
-  g_free (property_suffix);
   g_free (properties_array);
 
   return GSTD_EOK;
@@ -481,6 +480,7 @@ gstd_element_fill_child_properties (GstdElement * self, GstObject * element,
     gstd_element_append_object_properties (GST_OBJECT (child),
         self->element_properties, GST_ELEMENT_CAST (child), suffix);
 
+    g_free (suffix);
     g_object_unref (child);
   }
 

--- a/gstd/gstd_element.c
+++ b/gstd/gstd_element.c
@@ -420,6 +420,7 @@ gstd_element_append_object_properties (GstObject * object,
   gchar *property_name;
 
   g_return_val_if_fail (GST_IS_OBJECT (object), GSTD_NULL_ARGUMENT);
+  g_return_val_if_fail (GST_IS_OBJECT (target), GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (properties, GSTD_NULL_ARGUMENT);
 
   GST_DEBUG_OBJECT (target, "Gathering \"%s\" properties",

--- a/gstd/gstd_property.h
+++ b/gstd/gstd_property.h
@@ -50,6 +50,7 @@ struct _GstdProperty
 {
   GstdObject parent;
 
+  GParamSpec *pspec;
   GObject *target;
 };
 


### PR DESCRIPTION
This allows to set or get the properties of an element child,
just need to use the property name with the child name element.
For example to set a property,
     element_set <pipe> <element> <child>::<property> <value>