### PR TITLE
Feature/remove warnings

### DIFF
--- a/examples/libgstc/dynamic_property_change.c
+++ b/examples/libgstc/dynamic_property_change.c
@@ -47,7 +47,7 @@ sig_handler (int sig)
 }
 
 int
-main ()
+main (int argc, char *argv[])
 {
   GstClient *client;
   GstcStatus ret;

--- a/examples/libgstc/gapless_playback.c
+++ b/examples/libgstc/gapless_playback.c
@@ -38,6 +38,8 @@
 
 #include "libgstc.h"
 
+#define PIPELINE_DESC_FORMAT "playbin uri=file://%s"
+
 static int running = 1;
 
 static void
@@ -69,7 +71,6 @@ main (int argc, char *argv[])
   int asprintf_ret;
   const char *pipe_name = "pipe";
   char *pipe_description;
-  const char *pipe_description_template = "playbin uri=file://%s";
   char *video_name;
 
   if (argc != 2) {
@@ -84,7 +85,7 @@ main (int argc, char *argv[])
   }
 
   video_name = argv[1];
-  asprintf_ret = asprintf (&pipe_description, pipe_description_template, video_name);
+  asprintf_ret = asprintf (&pipe_description, PIPELINE_DESC_FORMAT, video_name);
   if (-1 == asprintf_ret) {
     goto free_client;
   }

--- a/examples/libgstc/mp4_recording.c
+++ b/examples/libgstc/mp4_recording.c
@@ -37,7 +37,7 @@
 #include "libgstc.h"
 
 int
-main ()
+main (int argc, char *argv[])
 {
   GstClient *client;
   GstcStatus ret;

--- a/examples/libgstc/simple_pipeline.c
+++ b/examples/libgstc/simple_pipeline.c
@@ -36,7 +36,7 @@
 #include "libgstc.h"
 
 int
-main ()
+main (int argc, char *argv[])
 {
   GstClient *client;
   GstcStatus ret;

--- a/gst_client/gst_client.c
+++ b/gst_client/gst_client.c
@@ -373,7 +373,7 @@ main (gint argc, gchar * argv[])
 
   if (version) {
     g_print ("" PACKAGE_STRING "\n");
-    g_print ("Copyright (c) 2015 RigeRun Engineering\n");
+    g_print ("Copyright (c) 2015 RidgeRun Engineering\n");
     return EXIT_SUCCESS;
   }
 

--- a/gst_client/gst_client.c
+++ b/gst_client/gst_client.c
@@ -68,17 +68,17 @@ typedef gint GstdClientCB (gchar *, gchar *, GstdClientData *);
 
 struct _GstdClientCmd
 {
-  gchar *name;
+  const gchar *name;
   GstdClientCB *func;
-  gchar *doc;
-  gchar *usage;
+  const gchar *doc;
+  const gchar *usage;
 };
 
 struct _GstdClientData
 {
   gboolean quiet;
   gboolean use_unix;
-  gchar *prompt;
+  const gchar *prompt;
   guint tcp_port;
   guint unix_port;
   gchar *address;
@@ -247,7 +247,7 @@ gstd_client_execute (gchar * line, GstdClientData * data)
   if (tokens[1])
     arg = g_strstrip (tokens[1]);
   else
-    arg = "";
+    arg = (gchar*)"";
 
   /* Find and execute the respective command */
   cmd = cmds;
@@ -271,7 +271,7 @@ main (gint argc, gchar * argv[])
   gchar *line;
   GError *error = NULL;
   GOptionContext *context;
-  gchar *prompt = "gstd> ";
+  const gchar *prompt = "gstd> ";
   const gchar *history = ".gstc_history";
   const gchar *history_env = "GSTC_HISTORY";
   gchar *history_full = NULL;
@@ -373,7 +373,7 @@ main (gint argc, gchar * argv[])
 
   if (version) {
     g_print ("" PACKAGE_STRING "\n");
-    g_print ("Copyright (c) 2015 RidgeRun Engineering\n");
+    g_print ("Copyright (c) 2015 RigeRun Engineering\n");
     return EXIT_SUCCESS;
   }
 
@@ -395,7 +395,7 @@ main (gint argc, gchar * argv[])
   signal (SIGINT, sig_handler);
 
   if (file && !quit) {
-    gstd_client_cmd_source ("source", file, data);
+    gstd_client_cmd_source ((gchar*)"source", file, data);
     g_free (file);
   }
 
@@ -459,7 +459,7 @@ static gchar *
 gstd_client_completer (const gchar * text, gint state)
 {
   static gint list_index, len;
-  gchar *name;
+  const gchar *name;
 
   /* If this is a new word to complete, initialize now.  This includes
      saving the length of TEXT for efficiency, and initializing the index

--- a/gst_client/gst_client.c
+++ b/gst_client/gst_client.c
@@ -218,7 +218,7 @@ sig_handler (gint signo)
 
 /* Customizing readline */
 static void
-init_readline ()
+init_readline (void)
 {
   /* Allow conditional parsing of the ~/.inputrc file */
   rl_readline_name = "Gstd";

--- a/gst_client/gst_client.c
+++ b/gst_client/gst_client.c
@@ -560,6 +560,7 @@ gstd_client_cmd_socket (gchar * name, gchar * arg, GstdClientData * data)
   GOutputStream *ostream;
   gchar buffer[1024 * 1024];
   gint read;
+  gchar * path_name;
 
   g_return_val_if_fail (name, -1);
   g_return_val_if_fail (arg, -1);
@@ -572,7 +573,7 @@ gstd_client_cmd_socket (gchar * name, gchar * arg, GstdClientData * data)
       GSocketAddress *socket_address;
       g_socket_client_set_family (data->client,
                                 G_SOCKET_FAMILY_UNIX);
-			gchar * path_name = g_strdup_printf ("%s_%d", data->address, data->unix_port);
+      path_name = g_strdup_printf ("%s_%d", data->address, data->unix_port);
       socket_address = g_unix_socket_address_new (path_name);
       g_free (path_name);
 

--- a/gstd/gstd.c
+++ b/gstd/gstd.c
@@ -40,17 +40,18 @@ static gboolean ipc_start (GstdIpc * ipc[], guint num_ipcs,
 static void ipc_stop (GstdIpc * ipc[], guint numipc);
 static void print_header (gboolean quiet);
 
+#define HEADER \
+      "\nGstd version " PACKAGE_VERSION "\n" \
+      "Copyright (C) 2015-2017 Ridgerun, LLC (http://www.ridgerun.com)\n\n" \
+      "Log traces will be saved to %s.\nDetaching from parent process."
+
 void
 print_header (gboolean quiet)
 {
-  const gchar *header = "\nGstd version " PACKAGE_VERSION "\n"
-      "Copyright (C) 2015-2017 Ridgerun, LLC (http://www.ridgerun.com)\n\n"
-      "Log traces will be saved to %s.\nDetaching from parent process.";
-
+  gchar *filename;
   if (!quiet) {
-    gchar *filename;
     filename = gstd_log_get_current_gstd ();
-    GST_INFO (header, filename);
+    GST_INFO (HEADER, filename);
     g_free (filename);
   }
 }

--- a/gstd/gstd.c
+++ b/gstd/gstd.c
@@ -145,7 +145,7 @@ main (gint argc, gchar * argv[])
 {
   GMainLoop *main_loop;
   GstdSession *session;
-  gboolean version = FALSE;;
+  gboolean version = FALSE;
   gboolean kill = FALSE;
   gboolean nodaemon = FALSE;
   gboolean quiet = FALSE;

--- a/gstd/gstd.c
+++ b/gstd/gstd.c
@@ -166,9 +166,9 @@ main (gint argc, gchar * argv[])
     GSTD_TYPE_UNIX,
   };
 
-  guint num_ipcs = (sizeof (supported_ipcs) / sizeof (GType));
-  GstdIpc *ipc_array[num_ipcs];
-  GOptionGroup *optiongroup_array[num_ipcs];
+  guint num_ipcs = (sizeof (supported_ipcs) / sizeof (GType));  
+  GstdIpc **ipc_array = g_malloc(num_ipcs * sizeof(GstdIpc*));
+  GOptionGroup **optiongroup_array = g_malloc(num_ipcs * sizeof(GOptionGroup*));
 
   GOptionEntry entries[] = {
     {"version", 'v', 0, G_OPTION_ARG_NONE, &version,
@@ -279,6 +279,9 @@ main (gint argc, gchar * argv[])
 
   gst_deinit ();
   gstd_log_deinit ();
+  
+  g_free(ipc_array);
+  g_free(optiongroup_array);
 
   goto out;
 

--- a/gstd/gstd.c
+++ b/gstd/gstd.c
@@ -40,17 +40,17 @@ static gboolean ipc_start (GstdIpc * ipc[], guint num_ipcs,
 static void ipc_stop (GstdIpc * ipc[], guint numipc);
 static void print_header (gboolean quiet);
 
+#define GSTD_HEADER "\nGstd version " PACKAGE_VERSION "\n" \
+      "Copyright (C) 2015-2017 Ridgerun, LLC (http://www.ridgerun.com)\n\n" \
+      "Log traces will be saved to %s.\nDetaching from parent process." 
+
 void
 print_header (gboolean quiet)
 {
-  const gchar *header = "\nGstd version " PACKAGE_VERSION "\n"
-      "Copyright (C) 2015-2017 Ridgerun, LLC (http://www.ridgerun.com)\n\n"
-      "Log traces will be saved to %s.\nDetaching from parent process.";
-
   if (!quiet) {
     gchar *filename;
     filename = gstd_log_get_current_gstd ();
-    GST_INFO (header, filename);
+    GST_INFO (GSTD_HEADER, filename);
     g_free (filename);
   }
 }

--- a/gstd/gstd.c
+++ b/gstd/gstd.c
@@ -40,17 +40,17 @@ static gboolean ipc_start (GstdIpc * ipc[], guint num_ipcs,
 static void ipc_stop (GstdIpc * ipc[], guint numipc);
 static void print_header (gboolean quiet);
 
-#define GSTD_HEADER "\nGstd version " PACKAGE_VERSION "\n" \
-      "Copyright (C) 2015-2017 Ridgerun, LLC (http://www.ridgerun.com)\n\n" \
-      "Log traces will be saved to %s.\nDetaching from parent process." 
-
 void
 print_header (gboolean quiet)
 {
+  const gchar *header = "\nGstd version " PACKAGE_VERSION "\n"
+      "Copyright (C) 2015-2017 Ridgerun, LLC (http://www.ridgerun.com)\n\n"
+      "Log traces will be saved to %s.\nDetaching from parent process.";
+
   if (!quiet) {
     gchar *filename;
     filename = gstd_log_get_current_gstd ();
-    GST_INFO (GSTD_HEADER, filename);
+    GST_INFO (header, filename);
     g_free (filename);
   }
 }

--- a/gstd/gstd_bus_msg.h
+++ b/gstd/gstd_bus_msg.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdBusMsg GstdBusMsg;
 typedef struct _GstdBusMsgClass GstdBusMsgClass;
-GType gstd_bus_msg_get_type ();
+GType gstd_bus_msg_get_type (void);
 
 struct _GstdBusMsg
 {

--- a/gstd/gstd_bus_msg_element.h
+++ b/gstd/gstd_bus_msg_element.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdBusMsgElement GstdBusMsgElement;
 typedef struct _GstdBusMsgElementClass GstdBusMsgElementClass;
-GType gstd_bus_msg_element_get_type ();
+GType gstd_bus_msg_element_get_type (void);
 
 G_END_DECLS
 

--- a/gstd/gstd_bus_msg_info.h
+++ b/gstd/gstd_bus_msg_info.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdBusMsgInfo GstdBusMsgInfo;
 typedef struct _GstdBusMsgInfoClass GstdBusMsgInfoClass;
-GType gstd_bus_msg_info_get_type ();
+GType gstd_bus_msg_info_get_type (void);
 
 G_END_DECLS
 

--- a/gstd/gstd_bus_msg_qos.h
+++ b/gstd/gstd_bus_msg_qos.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdBusMsgQos GstdBusMsgQos;
 typedef struct _GstdBusMsgQosClass GstdBusMsgQosClass;
-GType gstd_bus_msg_qos_get_type ();
+GType gstd_bus_msg_qos_get_type (void);
 
 G_END_DECLS
 

--- a/gstd/gstd_bus_msg_stream_status.h
+++ b/gstd/gstd_bus_msg_stream_status.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdBusMsgStreamStatus GstdBusMsgStreamStatus;
 typedef struct _GstdBusMsgStreamStatusClass GstdBusMsgStreamStatusClass;
-GType gstd_bus_msg_stream_status_get_type ();
+GType gstd_bus_msg_stream_status_get_type (void);
 
 G_END_DECLS
 

--- a/gstd/gstd_callback.h
+++ b/gstd/gstd_callback.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_CALLBACK, GstdCallbackClass))
 typedef struct _GstdCallback GstdCallback;
 typedef struct _GstdCallbackClass GstdCallbackClass;
-GType gstd_callback_get_type ();
+GType gstd_callback_get_type (void);
 
 struct _GstdCallback
 {

--- a/gstd/gstd_daemon.c
+++ b/gstd/gstd_daemon.c
@@ -37,9 +37,9 @@
 #include <libdaemon/dpid.h>
 #include <libdaemon/dexec.h>
 
-static gboolean gstd_daemon_start_parent ();
-static gboolean gstd_daemon_start_child ();
-static const gchar *gstd_daemon_pid ();
+static gboolean gstd_daemon_start_parent (void);
+static gboolean gstd_daemon_start_child (void);
+static const gchar *gstd_daemon_pid (void);
 static gchar *gstd_daemon_get_pid_filename (const gchar * filename);
 
 static gboolean _initialized = FALSE;

--- a/gstd/gstd_daemon.c
+++ b/gstd/gstd_daemon.c
@@ -120,7 +120,7 @@ out:
 }
 
 static gboolean
-gstd_daemon_start_parent ()
+gstd_daemon_start_parent (void)
 {
   gint iret;
   gboolean ret = FALSE;
@@ -144,7 +144,7 @@ gstd_daemon_start_parent ()
 }
 
 static gboolean
-gstd_daemon_start_child ()
+gstd_daemon_start_child (void)
 {
   gint retval = 0;
   gboolean ret;
@@ -177,7 +177,7 @@ out:
 }
 
 gboolean
-gstd_daemon_stop ()
+gstd_daemon_stop (void)
 {
   gboolean ret = FALSE;
   guint timeout = 5;
@@ -198,7 +198,7 @@ gstd_daemon_stop ()
 }
 
 static const gchar *
-gstd_daemon_pid ()
+gstd_daemon_pid (void)
 {
   static gchar *fn = NULL;
   gchar *filename;

--- a/gstd/gstd_daemon.h
+++ b/gstd/gstd_daemon.h
@@ -52,6 +52,6 @@ gboolean gstd_daemon_start (gboolean * parent);
  * \return TRUE if the daemon was successfully closed, FALSE
  * otherwise.
  */
-gboolean gstd_daemon_stop ();
+gboolean gstd_daemon_stop (void);
 
 #endif // __GSTD_DAEMON_H__

--- a/gstd/gstd_debug.c
+++ b/gstd/gstd_debug.c
@@ -82,7 +82,7 @@ static void gstd_debug_get_property (GObject *, guint, GValue *, GParamSpec *);
 static void gstd_debug_dispose (GObject *);
 
 gchar *
-debug_obtain_default_level ()
+debug_obtain_default_level (void)
 {
   gint level = gst_debug_get_default_threshold ();
   return g_strdup_printf ("%d", level);
@@ -271,7 +271,7 @@ gstd_debug_dispose (GObject * object)
 
 
 GstdDebug *
-gstd_debug_new ()
+gstd_debug_new (void)
 {
   return GSTD_DEBUG (g_object_new (GSTD_TYPE_DEBUG, NULL));
 }

--- a/gstd/gstd_debug.c
+++ b/gstd/gstd_debug.c
@@ -81,7 +81,7 @@ gstd_debug_set_property (GObject *, guint, const GValue *, GParamSpec *);
 static void gstd_debug_get_property (GObject *, guint, GValue *, GParamSpec *);
 static void gstd_debug_dispose (GObject *);
 
-gchar *
+static gchar *
 debug_obtain_default_level (void)
 {
   gint level = gst_debug_get_default_threshold ();

--- a/gstd/gstd_debug.c
+++ b/gstd/gstd_debug.c
@@ -93,12 +93,12 @@ gstd_debug_class_init (GstdDebugClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GParamSpec *properties[N_PROPERTIES] = { NULL, };
+  gchar *temp_threshold = debug_obtain_default_level ();
+  guint debug_color;
 
   object_class->set_property = gstd_debug_set_property;
   object_class->get_property = gstd_debug_get_property;
   object_class->dispose = gstd_debug_dispose;
-
-  gchar *temp_threshold = debug_obtain_default_level ();
 
   properties[PROP_ENABLE] =
       g_param_spec_boolean ("enable",
@@ -135,7 +135,7 @@ gstd_debug_class_init (GstdDebugClass * klass)
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 
   /* Initialize debug category with nice colors */
-  guint debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
+  debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
   GST_DEBUG_CATEGORY_INIT (gstd_debug_cat, "gstddebug", debug_color,
       "Gstd debug category");
 

--- a/gstd/gstd_debug.h
+++ b/gstd/gstd_debug.h
@@ -38,7 +38,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_DEBUG, GstdDebugClass))
 typedef struct _GstdDebug GstdDebug;
 typedef struct _GstdDebugClass GstdDebugClass;
-GType gstd_debug_get_type ();
+GType gstd_debug_get_type (void);
 
 /**
  * gstd_debug_new: (constructor)
@@ -48,7 +48,7 @@ GType gstd_debug_get_type ();
  * Returns: (transfer full) (nullable): A new #GstdDebug. Free after
  * usage using g_object_unref()
  */
-GstdDebug *gstd_debug_new ();
+GstdDebug *gstd_debug_new (void);
 
 
 #endif // __GSTD_DEBUG_H__

--- a/gstd/gstd_element.h
+++ b/gstd/gstd_element.h
@@ -40,7 +40,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_ELEMENT, GstdElementClass))
 typedef struct _GstdElement GstdElement;
 typedef struct _GstdElementClass GstdElementClass;
-GType gstd_element_get_type ();
+GType gstd_element_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_ELEMENT_H__

--- a/gstd/gstd_event_creator.c
+++ b/gstd/gstd_event_creator.c
@@ -81,6 +81,7 @@ gstd_event_creator_class_init (GstdEventCreatorClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GParamSpec *properties[N_PROPERTIES] = { NULL, };
+  guint debug_color;
   object_class->set_property = gstd_event_creator_set_property;
 
   properties[PROP_RECEIVER] =
@@ -93,7 +94,7 @@ gstd_event_creator_class_init (GstdEventCreatorClass * klass)
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 
   /* Initialize debug category with nice colors */
-  guint debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
+  debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
   GST_DEBUG_CATEGORY_INIT (gstd_event_creator_debug, "gstdeventcreator",
       debug_color, "Gstd Event Creator category");
 }

--- a/gstd/gstd_event_creator.h
+++ b/gstd/gstd_event_creator.h
@@ -40,7 +40,7 @@ G_BEGIN_DECLS
 typedef struct _GstdEventCreator GstdEventCreator;
 typedef struct _GstdEventCreatorClass GstdEventCreatorClass;
 
-GType gstd_event_creator_get_type ();
+GType gstd_event_creator_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_EVENT_CREATOR_H__

--- a/gstd/gstd_event_factory.c
+++ b/gstd/gstd_event_factory.c
@@ -172,6 +172,10 @@ gstd_event_factory_make_seek_event (const gchar * description)
   gint64 stop = GSTD_EVENT_FACTORY_SEEK_STOP_DEFAULT;
   GstEvent *event = NULL;
   gchar **tokens = NULL;
+  gint64 temp_format;
+  gint64 temp_flags;
+  gint64 temp_start_type;
+  gint64 temp_stop_type;
 
   if (NULL != description) {
     tokens = g_strsplit (description, " ", 7);
@@ -189,7 +193,6 @@ gstd_event_factory_make_seek_event (const gchar * description)
     goto fallback;
   }
 
-  gint64 temp_format;
   if (!gstd_ascii_to_gint64 (tokens[1], &temp_format)) {
     goto out;
   }
@@ -199,7 +202,6 @@ gstd_event_factory_make_seek_event (const gchar * description)
     goto fallback;
   }
 
-  gint64 temp_flags;
   if (!gstd_ascii_to_gint64 (tokens[2], &temp_flags)) {
     goto out;
   }
@@ -209,7 +211,6 @@ gstd_event_factory_make_seek_event (const gchar * description)
     goto fallback;
   }
 
-  gint64 temp_start_type;
   if (!gstd_ascii_to_gint64 (tokens[3], &temp_start_type)) {
     goto out;
   }
@@ -227,7 +228,6 @@ gstd_event_factory_make_seek_event (const gchar * description)
     goto fallback;
   }
 
-  gint64 temp_stop_type;
   if (!gstd_ascii_to_gint64 (tokens[5], &temp_stop_type)) {
     goto out;
   }

--- a/gstd/gstd_event_handler.c
+++ b/gstd/gstd_event_handler.c
@@ -58,6 +58,7 @@ static void gstd_event_handler_class_init (GstdEventHandlerClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GParamSpec *properties[N_PROPERTIES] = { NULL, };
+  guint debug_color;
 
   object_class->set_property = gstd_event_handler_set_property;
   object_class->dispose = gstd_event_handler_dispose;
@@ -72,7 +73,7 @@ static void gstd_event_handler_class_init (GstdEventHandlerClass * klass)
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 
   /* Initialize debug category with nice colors */
-  guint debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
+  debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
   GST_DEBUG_CATEGORY_INIT (gstd_event_handler_debug, "gstdevent_handlerhandler",
       debug_color, "Gstd EventHandler  category");
 }

--- a/gstd/gstd_event_handler.h
+++ b/gstd/gstd_event_handler.h
@@ -39,7 +39,7 @@ G_BEGIN_DECLS
 typedef struct _GstdEventHandler GstdEventHandler;
 typedef struct _GstdEventHandlerClass GstdEventHandlerClass;
 
-GType gstd_event_handler_get_type ();
+GType gstd_event_handler_get_type (void);
 
 /**
  * gstd_event_handler_new: (constructor)

--- a/gstd/gstd_json_builder.h
+++ b/gstd/gstd_json_builder.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdJsonBuilder GstdJsonBuilder;
 
-GType gstd_json_builder_get_type ();
+GType gstd_json_builder_get_type (void);
 
 G_END_DECLS
 

--- a/gstd/gstd_list.c
+++ b/gstd/gstd_list.c
@@ -288,7 +288,7 @@ gstd_list_to_string (GstdObject * object, gchar ** outstring)
   gchar *acc;
   gchar *node;
   GList *list;
-  gchar *separator;
+  const gchar *separator;
 
   g_return_val_if_fail (GSTD_IS_OBJECT (object), GSTD_NULL_ARGUMENT);
   g_warn_if_fail (!*outstring);

--- a/gstd/gstd_list.h
+++ b/gstd/gstd_list.h
@@ -65,7 +65,7 @@ struct _GstdListClass
   GstdObjectClass parent_class;
 };
 
-GType gstd_list_get_type ();
+GType gstd_list_get_type (void);
 
 GstdObject *gstd_list_find_child (GstdList * self, const gchar * name);
 gboolean gstd_list_append_child (GstdList *, GstdObject * child);

--- a/gstd/gstd_list_reader.h
+++ b/gstd/gstd_list_reader.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_LIST_READER, GstdListReaderClass))
 typedef struct _GstdListReader GstdListReader;
 
-GType gstd_list_reader_get_type ();
+GType gstd_list_reader_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_LIST_READER_H__

--- a/gstd/gstd_log.c
+++ b/gstd/gstd_log.c
@@ -39,8 +39,8 @@ gstd_log_proxy (GstDebugCategory * category, GstDebugLevel level,
     const gchar * file, const gchar * function, gint line, GObject * object,
     GstDebugMessage * message, gpointer user_data) G_GNUC_NO_INSTRUMENT;
 
-static const gchar *gstd_log_get_gstd_default ();
-static const gchar *gstd_log_get_gst_default ();
+static const gchar *gstd_log_get_gstd_default (void);
+static const gchar *gstd_log_get_gst_default (void);
 static gchar *gstd_log_get_filename (const gchar * filename, const gchar * default_filename);
 
 static FILE *_gstdlog = NULL;

--- a/gstd/gstd_log.c
+++ b/gstd/gstd_log.c
@@ -88,7 +88,7 @@ gstd_log_init (const gchar * gstdfilename, const gchar * gstfilename)
 }
 
 void
-gstd_log_deinit ()
+gstd_log_deinit (void)
 {
   g_free (gstd_filename);
   g_free (gst_filename);
@@ -123,13 +123,13 @@ gstd_log_proxy (GstDebugCategory * category, GstDebugLevel level,
 }
 
 static const gchar *
-gstd_log_get_gstd_default ()
+gstd_log_get_gstd_default (void)
 {
   return GSTD_LOG_STATE_DIR GSTD_LOG_NAME;
 }
 
 static const gchar *
-gstd_log_get_gst_default ()
+gstd_log_get_gst_default (void)
 {
   return GSTD_LOG_STATE_DIR GST_LOG_NAME;
 }
@@ -150,13 +150,13 @@ gstd_log_get_filename (const gchar * filename, const gchar * default_filename)
 }
 
 gchar *
-gstd_log_get_current_gstd ()
+gstd_log_get_current_gstd (void)
 {
   return g_strdup (gstd_filename);
 }
 
 gchar *
-gstd_log_get_current_gst ()
+gstd_log_get_current_gst (void)
 {
   return g_strdup (gst_filename);
 }

--- a/gstd/gstd_log.h
+++ b/gstd/gstd_log.h
@@ -22,11 +22,11 @@
 
 #include <gst/gst.h>
 
-void gstd_log_init ();
-void gstd_log_deinit ();
+void gstd_log_init (const gchar * gstdfilename, const gchar * gstfilename);
+void gstd_log_deinit (void);
 
-gchar *gstd_log_get_current_gstd ();
-gchar *gstd_log_get_current_gst ();
+gchar *gstd_log_get_current_gstd (void);
+gchar *gstd_log_get_current_gst (void);
 
 /* A default category for every object not defining its own */
 GST_DEBUG_CATEGORY_EXTERN (gstd_debug);

--- a/gstd/gstd_msg_reader.h
+++ b/gstd/gstd_msg_reader.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_MSG_READER, GstdMsgReaderClass))
 typedef struct _GstdMsgReader GstdMsgReader;
 
-GType gstd_msg_reader_get_type ();
+GType gstd_msg_reader_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_MSG_READER_H__

--- a/gstd/gstd_msg_type.h
+++ b/gstd/gstd_msg_type.h
@@ -29,7 +29,7 @@ G_BEGIN_DECLS
  */
 #define GSTD_TYPE_MSG_TYPE (gstd_msg_type_get_type())
 
-GType gstd_msg_type_get_type ();
+GType gstd_msg_type_get_type (void);
 
 G_END_DECLS
 

--- a/gstd/gstd_no_creator.h
+++ b/gstd/gstd_no_creator.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_NO_CREATOR, GstdNoCreatorClass))
 typedef struct _GstdNoCreator GstdNoCreator;
 
-GType gstd_no_creator_get_type ();
+GType gstd_no_creator_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_NO_CREATOR_H__

--- a/gstd/gstd_no_deleter.h
+++ b/gstd/gstd_no_deleter.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_NO_DELETER, GstdNoDeleterClass))
 typedef struct _GstdNoDeleter GstdNoDeleter;
 
-GType gstd_no_deleter_get_type ();
+GType gstd_no_deleter_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_NO_DELETER_H__

--- a/gstd/gstd_no_reader.h
+++ b/gstd/gstd_no_reader.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_NO_READER, GstdNoReaderClass))
 typedef struct _GstdNoReader GstdNoReader;
 
-GType gstd_no_reader_get_type ();
+GType gstd_no_reader_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_NO_READER_H__

--- a/gstd/gstd_no_updater.h
+++ b/gstd/gstd_no_updater.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_NO_UPDATER, GstdNoUpdaterClass))
 typedef struct _GstdNoUpdater GstdNoUpdater;
 
-GType gstd_no_updater_get_type ();
+GType gstd_no_updater_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_NO_UPDATER_H__

--- a/gstd/gstd_parser.c
+++ b/gstd/gstd_parser.c
@@ -95,7 +95,7 @@ static GstdReturnCode gstd_parser_debug_reset (GstdSession *, gchar *, gchar *,
 typedef GstdReturnCode GstdFunc (GstdSession *, gchar *, gchar *, gchar **);
 typedef struct _GstdCmd
 {
-  gchar *cmd;
+  const gchar *cmd;
   GstdFunc *callback;
 } GstdCmd;
 
@@ -161,7 +161,7 @@ gstd_parser_parse_raw_cmd (GstdSession * session, gchar * action, gchar * args,
 
   // Alias the empty string to the base
   if (!uri)
-    uri = "/";
+    uri = (gchar*)"/";
 
   ret = gstd_get_by_uri (session, uri, &node);
   if (ret || NULL == node) {
@@ -342,7 +342,7 @@ gstd_parser_pipeline_create (GstdSession * session, gchar * action, gchar * args
 
   uri = g_strdup_printf ("/pipelines %s", args ? args : "");
 
-  ret = gstd_parser_parse_raw_cmd (session, "create", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"create", uri, response);
 
   g_free (uri);
 
@@ -360,7 +360,7 @@ gstd_parser_pipeline_delete (GstdSession * session, gchar * action, gchar * args
   g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines %s", args);
-  ret = gstd_parser_parse_raw_cmd (session, "delete", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"delete", uri, response);
   g_free (uri);
 
   return ret;
@@ -377,7 +377,7 @@ gstd_parser_pipeline_play (GstdSession * session, gchar * action, gchar * args,
   g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines/%s/state playing", args);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
   g_free (uri);
 
   return ret;
@@ -394,7 +394,7 @@ gstd_parser_pipeline_pause (GstdSession * session, gchar * action, gchar * args,
   g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines/%s/state paused", args);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
   g_free (uri);
 
   return ret;
@@ -411,7 +411,7 @@ gstd_parser_pipeline_stop (GstdSession * session, gchar * action, gchar * args,
   g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines/%s/state null", args);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
   g_free (uri);
 
   return ret;
@@ -436,7 +436,7 @@ gstd_parser_element_set (GstdSession * session, gchar * action, gchar * args,
 
   uri = g_strdup_printf ("/pipelines/%s/elements/%s/properties/%s %s",
       tokens[0], tokens[1], tokens[2], tokens[3]);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -462,7 +462,7 @@ gstd_parser_element_get (GstdSession * session, gchar * action, gchar * args,
 
   uri = g_strdup_printf ("/pipelines/%s/elements/%s/properties/%s",
       tokens[0], tokens[1], tokens[2]);
-  ret = gstd_parser_parse_raw_cmd (session, "read", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"read", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -480,7 +480,7 @@ gstd_parser_list_pipelines (GstdSession * session, gchar * action, gchar * args,
   g_return_val_if_fail (GSTD_IS_SESSION (session), GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines");
-  ret = gstd_parser_parse_raw_cmd (session, "read", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"read", uri, response);
   g_free (uri);
 
   return ret;
@@ -497,7 +497,7 @@ gstd_parser_list_elements (GstdSession * session, gchar * action, gchar * args,
   g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines/%s/elements/", args);
-  ret = gstd_parser_parse_raw_cmd (session, "read", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"read", uri, response);
   g_free (uri);
 
   return ret;
@@ -521,7 +521,7 @@ gstd_parser_list_properties (GstdSession * session, gchar * action, gchar * args
   uri =
       g_strdup_printf ("/pipelines/%s/elements/%s/properties", tokens[0],
       tokens[1]);
-  ret = gstd_parser_parse_raw_cmd (session, "read", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"read", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -547,7 +547,7 @@ gstd_parser_list_signals (GstdSession * session, gchar * action, gchar * args,
   uri =
       g_strdup_printf ("/pipelines/%s/elements/%s/signals", tokens[0],
       tokens[1]);
-  ret = gstd_parser_parse_raw_cmd (session, "read", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"read", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -567,7 +567,7 @@ gstd_parser_bus_read (GstdSession * session, gchar * action,
   g_return_val_if_fail (response, GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines/%s/bus/message", pipeline);
-  ret = gstd_parser_parse_raw_cmd (session, "read", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"read", uri, response);
 
   g_free (uri);
 
@@ -591,7 +591,7 @@ gstd_parser_bus_filter (GstdSession * session, gchar * action,
   check_argument (tokens[1], GSTD_BAD_COMMAND);
 
   uri = g_strdup_printf ("/pipelines/%s/bus/types %s", tokens[0], tokens[1]);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -616,7 +616,7 @@ gstd_parser_bus_timeout (GstdSession * session, gchar * action, gchar * args,
   check_argument (tokens[1], GSTD_BAD_COMMAND);
 
   uri = g_strdup_printf ("/pipelines/%s/bus/timeout %s", tokens[0], tokens[1]);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -636,7 +636,7 @@ gstd_parser_event_eos (GstdSession * session, gchar * action, gchar * pipeline,
   g_return_val_if_fail (response, GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines/%s/event eos", pipeline);
-  ret = gstd_parser_parse_raw_cmd (session, "create", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"create", uri, response);
 
   g_free (uri);
 
@@ -660,7 +660,7 @@ gstd_parser_event_seek (GstdSession * session, gchar * action, gchar * args,
   // We don't check for the second token since we want to allow defaults
 
   uri = g_strdup_printf ("/pipelines/%s/event seek %s", tokens[0], tokens[1]);
-  ret = gstd_parser_parse_raw_cmd (session, "create", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"create", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -680,7 +680,7 @@ gstd_parser_event_flush_start (GstdSession * session, gchar * action,
   g_return_val_if_fail (response, GSTD_NULL_ARGUMENT);
 
   uri = g_strdup_printf ("/pipelines/%s/event flush_start", pipeline);
-  ret = gstd_parser_parse_raw_cmd (session, "create", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"create", uri, response);
 
   g_free (uri);
 
@@ -706,7 +706,7 @@ gstd_parser_event_flush_stop (GstdSession * session, gchar * action, gchar * arg
   uri =
       g_strdup_printf ("/pipelines/%s/event flush_stop %s", tokens[0],
       tokens[1]);
-  ret = gstd_parser_parse_raw_cmd (session, "create", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"create", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -727,7 +727,7 @@ gstd_parser_debug_enable (GstdSession * session, gchar * action, gchar * enabled
   check_argument (enabled, GSTD_BAD_COMMAND);
 
   uri = g_strdup_printf ("/debug/enable %s", enabled);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
 
   g_free (uri);
 
@@ -747,7 +747,7 @@ gstd_parser_debug_threshold (GstdSession * session, gchar * action,
   check_argument (threshold, GSTD_BAD_COMMAND);
 
   uri = g_strdup_printf ("/debug/threshold %s", threshold);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
 
   g_free (uri);
 
@@ -767,7 +767,7 @@ gstd_parser_debug_color (GstdSession * session, gchar * action, gchar * colored,
   check_argument (colored, GSTD_BAD_COMMAND);
 
   uri = g_strdup_printf ("/debug/color %s", colored);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
 
   g_free (uri);
 
@@ -788,7 +788,7 @@ gstd_parser_debug_reset (GstdSession * session, gchar * action, gchar * reset,
   check_argument (reset, GSTD_BAD_COMMAND);
 
   uri = g_strdup_printf ("/debug/reset %s", reset);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
 
   g_free (uri);
 
@@ -815,7 +815,7 @@ gstd_parser_signal_connect (GstdSession * session, gchar * action,
   
   uri = g_strdup_printf ("/pipelines/%s/elements/%s/signals/%s/callback",
 			 tokens[0], tokens[1], tokens[2]);
-  ret = gstd_parser_parse_raw_cmd (session, "read", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"read", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -843,7 +843,7 @@ gstd_parser_signal_disconnect (GstdSession * session, gchar * action,
   
   uri = g_strdup_printf ("/pipelines/%s/elements/%s/signals/%s/disconnect",
 			 tokens[0], tokens[1], tokens[2]);
-  ret = gstd_parser_parse_raw_cmd (session, "read", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"read", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);
@@ -873,7 +873,7 @@ gstd_parser_signal_timeout (GstdSession * session, gchar * action, gchar * args,
 
   uri = g_strdup_printf ("/pipelines/%s/elements/%s/signals/%s/timeout %s",
 			 tokens[0], tokens[1], tokens[2], tokens[3]);
-  ret = gstd_parser_parse_raw_cmd (session, "update", uri, response);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar*)"update", uri, response);
 
   g_free (uri);
   g_strfreev (tokens);

--- a/gstd/gstd_pipeline.c
+++ b/gstd/gstd_pipeline.c
@@ -53,6 +53,8 @@ GST_DEBUG_CATEGORY_STATIC (gstd_pipeline_debug);
 
 #define GSTD_DEBUG_DEFAULT_LEVEL GST_LEVEL_INFO
 
+#define FB_NAME "pipeline%d"
+
 /**
  * GstdPipeline:
  * A wrapper for the conventional pipeline
@@ -354,7 +356,6 @@ gstd_pipeline_create (GstdPipeline * self, const gchar * name,
     const gint index, const gchar * description)
 {
   GError *error;
-  const gchar *fbname = "pipeline%d";
   gchar *pipename;
   GstParseFlags flags;
 
@@ -385,7 +386,7 @@ gstd_pipeline_create (GstdPipeline * self, const gchar * name,
   /* If the user didn't provide a name or provided an empty name
    * assign the fallback using the idex */
   if (!name || name[0] == '\0') {
-    pipename = g_strdup_printf (fbname, index);
+    pipename = g_strdup_printf (FB_NAME, index);
   } else {
     pipename = g_strdup (name);
   }

--- a/gstd/gstd_pipeline.h
+++ b/gstd/gstd_pipeline.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_PIPELINE, GstdPipelineClass))
 typedef struct _GstdPipeline GstdPipeline;
 typedef struct _GstdPipelineClass GstdPipelineClass;
-GType gstd_pipeline_get_type ();
+GType gstd_pipeline_get_type (void);
 
 GstdReturnCode gstd_pipeline_build (GstdPipeline * object);
 

--- a/gstd/gstd_pipeline_bus.c
+++ b/gstd/gstd_pipeline_bus.c
@@ -71,6 +71,7 @@ gstd_pipeline_bus_class_init (GstdPipelineBusClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GParamSpec *properties[N_PROPERTIES] = { NULL, };
+  guint debug_color;
 
   object_class->set_property = gstd_pipeline_bus_set_property;
   object_class->get_property = gstd_pipeline_bus_get_property;
@@ -102,7 +103,7 @@ gstd_pipeline_bus_class_init (GstdPipelineBusClass * klass)
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 
   /* Initialize debug category with nice colors */
-  guint debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
+  debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
   GST_DEBUG_CATEGORY_INIT (gstd_pipeline_bus_debug, "gstdpipelinebus",
       debug_color, "Gstd Pipeline Bus messages category");
 }

--- a/gstd/gstd_pipeline_bus.h
+++ b/gstd/gstd_pipeline_bus.h
@@ -40,7 +40,7 @@ G_BEGIN_DECLS
 typedef struct _GstdPipelineBus GstdPipelineBus;
 typedef struct _GstdPipelineBusClass GstdPipelineBusClass;
 
-GType gstd_pipeline_bus_get_type ();
+GType gstd_pipeline_bus_get_type (void);
 
 /**
  * gstd_pipeline_bus_new: (constructor)

--- a/gstd/gstd_pipeline_creator.h
+++ b/gstd/gstd_pipeline_creator.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_PIPELINE_CREATOR, GstdPipelineCreatorClass))
 typedef struct _GstdPipelineCreator GstdPipelineCreator;
 
-GType gstd_pipeline_creator_get_type ();
+GType gstd_pipeline_creator_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_PIPELINE_CREATOR_H__

--- a/gstd/gstd_pipeline_deleter.h
+++ b/gstd/gstd_pipeline_deleter.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_PIPELINE_DELETER, GstdPipelineDeleterClass))
 typedef struct _GstdPipelineDeleter GstdPipelineDeleter;
 
-GType gstd_pipeline_deleter_get_type ();
+GType gstd_pipeline_deleter_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_PIPELINE_DELETER_H__

--- a/gstd/gstd_property.h
+++ b/gstd/gstd_property.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdProperty GstdProperty;
 typedef struct _GstdPropertyClass GstdPropertyClass;
-GType gstd_property_get_type ();
+GType gstd_property_get_type (void);
 
 struct _GstdProperty
 {

--- a/gstd/gstd_property_array.h
+++ b/gstd/gstd_property_array.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdPropertyArray GstdPropertyArray;
 typedef struct _GstdPropertyArrayClass GstdPropertyArrayClass;
-GType gstd_property_array_get_type();
+GType gstd_property_array_get_type(void);
 
 
 struct _GstdPropertyArray

--- a/gstd/gstd_property_boolean.h
+++ b/gstd/gstd_property_boolean.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdPropertyBoolean GstdPropertyBoolean;
 typedef struct _GstdPropertyBooleanClass GstdPropertyBooleanClass;
-GType gstd_property_boolean_get_type ();
+GType gstd_property_boolean_get_type (void);
 
 
 struct _GstdPropertyBoolean

--- a/gstd/gstd_property_enum.h
+++ b/gstd/gstd_property_enum.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdPropertyEnum GstdPropertyEnum;
 typedef struct _GstdPropertyEnumClass GstdPropertyEnumClass;
-GType gstd_property_enum_get_type ();
+GType gstd_property_enum_get_type (void);
 
 
 struct _GstdPropertyEnum

--- a/gstd/gstd_property_flags.h
+++ b/gstd/gstd_property_flags.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdPropertyFlags GstdPropertyFlags;
 typedef struct _GstdPropertyFlagsClass GstdPropertyFlagsClass;
-GType gstd_property_flags_get_type ();
+GType gstd_property_flags_get_type (void);
 
 
 struct _GstdPropertyFlags

--- a/gstd/gstd_property_int.h
+++ b/gstd/gstd_property_int.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdPropertyInt GstdPropertyInt;
 typedef struct _GstdPropertyIntClass GstdPropertyIntClass;
-GType gstd_property_int_get_type ();
+GType gstd_property_int_get_type (void);
 
 
 struct _GstdPropertyInt

--- a/gstd/gstd_property_reader.h
+++ b/gstd/gstd_property_reader.h
@@ -42,7 +42,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_PROPERTY_READER, GstdPropertyReaderClass))
 typedef struct _GstdPropertyReader GstdPropertyReader;
 
-GType gstd_property_reader_get_type ();
+GType gstd_property_reader_get_type (void);
 
 typedef struct _GstdPropertyReaderClass GstdPropertyReaderClass;
 

--- a/gstd/gstd_property_string.h
+++ b/gstd/gstd_property_string.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdPropertyString GstdPropertyString;
 typedef struct _GstdPropertyStringClass GstdPropertyStringClass;
-GType gstd_property_string_get_type ();
+GType gstd_property_string_get_type (void);
 
 
 struct _GstdPropertyString

--- a/gstd/gstd_session.c
+++ b/gstd/gstd_session.c
@@ -65,8 +65,9 @@ gstd_session_constructor (GType type,
     guint n_construct_params, GObjectConstructParam * construct_params)
 {
   static GObject *the_session = NULL;
-  g_mutex_lock (&singleton_mutex);
   GObject *object = NULL;
+  g_mutex_lock (&singleton_mutex);
+
   if (the_session == NULL) {
     object =
         G_OBJECT_CLASS (gstd_session_parent_class)->constructor (type,
@@ -89,6 +90,7 @@ gstd_session_class_init (GstdSessionClass * klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GParamSpec *properties[N_PROPERTIES] = { NULL, };
+  guint debug_color;
 
   object_class->set_property = gstd_session_set_property;
   object_class->get_property = gstd_session_get_property;
@@ -120,7 +122,7 @@ gstd_session_class_init (GstdSessionClass * klass)
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 
   /* Initialize debug category with nice colors */
-  guint debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
+  debug_color = GST_DEBUG_FG_BLACK | GST_DEBUG_BOLD | GST_DEBUG_BG_WHITE;
   GST_DEBUG_CATEGORY_INIT (gstd_session_debug, "gstdsession", debug_color,
       "Gstd Session category");
 }

--- a/gstd/gstd_signal.h
+++ b/gstd/gstd_signal.h
@@ -43,7 +43,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdSignal GstdSignal;
 typedef struct _GstdSignalClass GstdSignalClass;
-GType gstd_signal_get_type ();
+GType gstd_signal_get_type (void);
 
 struct _GstdSignal
 {

--- a/gstd/gstd_signal_list.h
+++ b/gstd/gstd_signal_list.h
@@ -57,7 +57,7 @@ struct _GstdSignalListClass
   GstdListClass parent_class;
 };
 
-GType gstd_signal_list_get_type ();
+GType gstd_signal_list_get_type (void);
 
 G_END_DECLS
 #endif // __GSTD_SIGNAL_LIST_H__

--- a/gstd/gstd_signal_reader.h
+++ b/gstd/gstd_signal_reader.h
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_SIGNAL_READER, GstdSignalReaderClass))
 typedef struct _GstdSignalReader GstdSignalReader;
 
-GType gstd_signal_reader_get_type ();
+GType gstd_signal_reader_get_type (void);
 
 GstdReturnCode gstd_signal_reader_disconnect (GstdIReader * iface);
 

--- a/gstd/gstd_socket.c
+++ b/gstd/gstd_socket.c
@@ -63,8 +63,8 @@ gstd_socket_class_init (GstdSocketClass * klass)
 static void
 gstd_socket_init (GstdSocket * self)
 {
-  GST_INFO_OBJECT (self, "Initializing gstd Socket");
   GstdIpc *base = GSTD_IPC (self);
+  GST_INFO_OBJECT (self, "Initializing gstd Socket");
   self->service = NULL;
   base->enabled = FALSE;
 }

--- a/gstd/gstd_socket.c
+++ b/gstd/gstd_socket.c
@@ -144,6 +144,7 @@ gstd_socket_start (GstdIpc * base, GstdSession * session)
 {
   GstdSocket *self = GSTD_SOCKET (base);
   GSocketService *service;
+  GstdReturnCode ret;
 
   if (!base->enabled) {
     GST_DEBUG_OBJECT (self, "SOCKET not enabled, skipping");
@@ -157,7 +158,6 @@ gstd_socket_start (GstdIpc * base, GstdSession * session)
 
   service = self->service;
 
- GstdReturnCode ret;
  ret = GSTD_SOCKET_GET_CLASS (self)->create_socket_service (self, &service);
 
  if(ret != GSTD_EOK)
@@ -179,13 +179,14 @@ gstd_socket_stop (GstdIpc * base)
   GstdSocket *self = GSTD_SOCKET (base);
   GSocketService *service;
   GstdSession *session = base->session;
+  GSocketListener *listener;
 
   g_return_val_if_fail (session, GSTD_NULL_ARGUMENT);
 
   GST_DEBUG_OBJECT (self, "Entering SOCKET stop ");
   if (self->service) {
     service = self->service;
-    GSocketListener *listener = G_SOCKET_LISTENER (service);
+    listener = G_SOCKET_LISTENER (service);
     if (service) {
       GST_INFO_OBJECT (session, "Closing SOCKET connection for %s",
           GSTD_OBJECT_NAME (session));

--- a/gstd/gstd_socket.h
+++ b/gstd/gstd_socket.h
@@ -52,7 +52,7 @@ struct _GstdSocketClass
   GstdReturnCode (*create_socket_service) (GstdSocket *, GSocketService **);
 };
 
-GType gstd_socket_get_type ();
+GType gstd_socket_get_type (void);
 
 G_END_DECLS
 #endif //__GSTD_SOCKET_H__

--- a/gstd/gstd_state.h
+++ b/gstd/gstd_state.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 typedef struct _GstdState GstdState;
 typedef struct _GstdStateClass GstdStateClass;
 
-GType gstd_state_get_type ();
+GType gstd_state_get_type (void);
 
 GstdState *gstd_state_new (GstElement * target);
 

--- a/gstd/gstd_tcp.c
+++ b/gstd/gstd_tcp.c
@@ -144,7 +144,6 @@ gboolean
 gstd_tcp_init_get_option_group (GstdIpc * base, GOptionGroup ** group)
 {
   GstdTcp *self = GSTD_TCP (base);
-  GST_DEBUG_OBJECT (self, "TCP init group callback ");
   GOptionEntry tcp_args[] = {
     {"enable-tcp-protocol", 't', 0, G_OPTION_ARG_NONE, &base->enabled,
         "Enable attach the server through given TCP ports ", NULL}
@@ -168,6 +167,7 @@ gstd_tcp_init_get_option_group (GstdIpc * base, GOptionGroup ** group)
     ,
     {NULL}
   };
+  GST_DEBUG_OBJECT (self, "TCP init group callback ");
   *group = g_option_group_new ("gstd-tcp", ("TCP Options"),
       ("Show TCP Options"), NULL, NULL);
 

--- a/gstd/gstd_tcp.h
+++ b/gstd/gstd_tcp.h
@@ -45,7 +45,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_TPC, GstdTcpClass))
 typedef struct _GstdTcp GstdTcp;
 typedef struct _GstdTcpClass GstdTcpClass;
-GType gstd_tcp_get_type ();
+GType gstd_tcp_get_type (void);
 
 
 G_END_DECLS

--- a/gstd/gstd_unix.c
+++ b/gstd/gstd_unix.c
@@ -89,9 +89,9 @@ gstd_unix_set_path (GstdUnix * self, const gchar * path)
 static void
 gstd_unix_init (GstdUnix * self)
 {
+  gchar *default_path;
   GST_INFO_OBJECT (self, "Initializing gstd Unix");
 
-  gchar *default_path;
   default_path = g_strdup_printf ("%s/%s", GSTD_RUN_STATE_DIR, GSTD_UNIX_DEFAULT_BASE_NAME);
   gstd_unix_set_path(self, default_path);
   g_free (default_path);

--- a/gstd/gstd_unix.c
+++ b/gstd/gstd_unix.c
@@ -172,7 +172,6 @@ gboolean
 gstd_unix_init_get_option_group (GstdIpc * base, GOptionGroup ** group)
 {
   GstdUnix *self = GSTD_UNIX (base);
-  GST_DEBUG_OBJECT (self, "UNIX init group callback ");
   GOptionEntry unix_args[] = {
     {"enable-unix-protocol", 'u', 0, G_OPTION_ARG_NONE, &base->enabled,
         "Enable attach the server through given UNIX socket ", NULL}
@@ -188,6 +187,7 @@ gstd_unix_init_get_option_group (GstdIpc * base, GOptionGroup ** group)
     ,
     {NULL}
   };
+    GST_DEBUG_OBJECT (self, "UNIX init group callback ");
   *group = g_option_group_new ("gstd-unix", ("UNIX Options"),
       ("Show UNIX Options"), NULL, NULL);
 

--- a/gstd/gstd_unix.h
+++ b/gstd/gstd_unix.h
@@ -39,7 +39,7 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GSTD_TYPE_TPC, GstdUnixClass))
 typedef struct _GstdUnix GstdUnix;
 typedef struct _GstdUnixClass GstdUnixClass;
-GType gstd_unix_get_type ();
+GType gstd_unix_get_type (void);
 
 
 G_END_DECLS

--- a/libgstc/libgstc.c
+++ b/libgstc/libgstc.c
@@ -45,6 +45,26 @@
 
 #define PRINTF_ERROR -1
 
+/* Gst client command update formats */
+#define CREATE_FORMAT "create %s %s"
+#define READ_FORMAT   "read %s"
+#define UPDATE_FORMAT "update %s %s"
+#define DELETE_FORMAT "delete %s %s"
+
+#define PIPELINE_CREATE_FORMAT               "%s %s"
+#define PIPELINE_STATE_FORMAT                "/pipelines/%s/state"
+#define PIPELINE_BUS_FORMAT                  "/pipelines/%s/bus/%s"
+#define PIPELINE_BUS_MSG_FORMAT              "/pipelines/%s/bus/message"
+#define PIPELINE_ELEMENTS_FORMAT             "/pipelines/%s/elements/"
+#define PIPELINE_ELEMENTS_PROPERTIES_FORMAT  "/pipelines/%s/elements/%s/properties"
+#define PIPELINE_ELEMENTS_PROPERTY_FORMAT    "/pipelines/%s/elements/%s/properties/%s"
+#define PIPELINE_EVENT_FORMAT                "/pipelines/%s/event"
+
+#define SEEK_FORMAT        "seek %f %d %d %d %lld %d %lld"
+#define FLUSH_STOP_FORMAT  "flush_stop %s"
+#define TIMEOUT_FORMAT  "%lli"
+
+
 static GstcStatus gstc_cmd_send (GstClient * client, const char *request);
 static GstcStatus gstc_cmd_send_get_response (GstClient * client,
     const char *request, char **reponse, const int timeout);
@@ -153,7 +173,6 @@ gstc_cmd_create (GstClient * client, const char *where, const char *what)
 {
   GstcStatus ret;
   int asprintf_ret;
-  const char *template = "create %s %s";
   char *request;
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
@@ -161,7 +180,7 @@ gstc_cmd_create (GstClient * client, const char *where, const char *what)
   gstc_assert_and_ret_val (NULL != what, GSTC_NULL_ARGUMENT);
 
   /* Concatenate pieces into request */
-  asprintf_ret = asprintf (&request, template, where, what);
+  asprintf_ret = asprintf (&request, CREATE_FORMAT, where, what);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -179,14 +198,13 @@ gstc_cmd_read (GstClient * client, const char *what, char **response,
 {
   GstcStatus ret;
   int asprintf_ret;
-  const char *template = "read %s";
   char *request;
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != what, GSTC_NULL_ARGUMENT);
 
   /* Concatenate pieces into request */
-  asprintf_ret = asprintf (&request, template, what);
+  asprintf_ret = asprintf (&request, READ_FORMAT, what);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -203,7 +221,6 @@ gstc_cmd_update (GstClient * client, const char *what, const char *how)
 {
   GstcStatus ret;
   int asprintf_ret;
-  const char *template = "update %s %s";
   char *request;
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
@@ -211,7 +228,7 @@ gstc_cmd_update (GstClient * client, const char *what, const char *how)
   gstc_assert_and_ret_val (NULL != how, GSTC_NULL_ARGUMENT);
 
   /* Concatenate pieces into request */
-  asprintf_ret = asprintf (&request, template, what, how);
+  asprintf_ret = asprintf (&request, UPDATE_FORMAT, what, how);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -228,7 +245,6 @@ gstc_cmd_delete (GstClient * client, const char *where, const char *what)
 {
   GstcStatus ret;
   int asprintf_ret;
-  const char *template = "delete %s %s";
   char *request;
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
@@ -236,7 +252,7 @@ gstc_cmd_delete (GstClient * client, const char *where, const char *what)
   gstc_assert_and_ret_val (NULL != what, GSTC_NULL_ARGUMENT);
 
   /* Concatenate pieces into request */
-  asprintf_ret = asprintf (&request, template, where, what);
+  asprintf_ret = asprintf (&request, DELETE_FORMAT, where, what);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -286,14 +302,13 @@ gstc_pipeline_create (GstClient * client, const char *pipeline_name,
   GstcStatus ret;
   int asprintf_ret;
   const char *resource = "/pipelines";
-  const char *template = "%s %s";
   char *create_args;
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != pipeline_name, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != pipeline_desc, GSTC_NULL_ARGUMENT);
 
-  asprintf_ret = asprintf (&create_args, template, pipeline_name, pipeline_desc);
+  asprintf_ret = asprintf (&create_args, PIPELINE_CREATE_FORMAT, pipeline_name, pipeline_desc);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -324,14 +339,13 @@ gstc_cmd_change_state (GstClient * client, const char *pipe, const char *state)
 {
   GstcStatus ret;
   int asprintf_ret;
-  const char *template = "/pipelines/%s/state";
   char *resource;
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != pipe, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != state, GSTC_NULL_ARGUMENT);
 
-  asprintf_ret = asprintf (&resource, template, pipe);
+  asprintf_ret = asprintf (&resource, PIPELINE_STATE_FORMAT, pipe);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -441,7 +455,6 @@ gstc_element_get (GstClient * client, const char *pname,
   GstcStatus ret;
   int asprintf_ret;
   va_list ap;
-  const char *what_fmt = "/pipelines/%s/elements/%s/properties/%s";
   char *what;
   char *response;
   char *out;
@@ -454,7 +467,7 @@ gstc_element_get (GstClient * client, const char *pname,
 
   va_start (ap, format);
 
-  asprintf_ret = asprintf (&what, what_fmt, pname, element, property);
+  asprintf_ret = asprintf (&what, PIPELINE_ELEMENTS_PROPERTY_FORMAT, pname, element, property);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -488,13 +501,12 @@ gstc_element_set (GstClient * client, const char *pname,
 {
   va_list ap;
   int asprintf_ret;
-  const char *what_fmt = "/pipelines/%s/elements/%s/properties/%s";
   char *what;
   char *how;
 
   va_start (ap, format);
 
-  asprintf_ret = asprintf (&what, what_fmt, pname, element, parameter);
+  asprintf_ret = asprintf (&what, PIPELINE_ELEMENTS_PROPERTY_FORMAT, pname, element, parameter);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -520,12 +532,11 @@ gstc_pipeline_flush_start (GstClient * client, const char *pipeline_name)
   int asprintf_ret;
   char *where;
   const char *what = "flush_start";
-  const char *where_fmt = "/pipelines/%s/event";
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != pipeline_name, GSTC_NULL_ARGUMENT);
 
-  asprintf_ret = asprintf (&where, where_fmt, pipeline_name);
+  asprintf_ret = asprintf (&where, PIPELINE_EVENT_FORMAT, pipeline_name);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -545,21 +556,19 @@ gstc_pipeline_flush_stop (GstClient * client, const char *pipeline_name,
   int asprintf_ret;
   char *where;
   char *what;
-  const char *what_fmt = "flush_stop %s";
-  const char *where_fmt = "/pipelines/%s/event";
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != pipeline_name, GSTC_NULL_ARGUMENT);
 
-  asprintf_ret = asprintf (&where, where_fmt, pipeline_name);
+  asprintf_ret = asprintf (&where, PIPELINE_EVENT_FORMAT, pipeline_name);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
 
   if (reset != 0) {
-    asprintf_ret = asprintf (&what, what_fmt, "true");
+    asprintf_ret = asprintf (&what, FLUSH_STOP_FORMAT, "true");
   } else {
-    asprintf_ret = asprintf (&what, what_fmt, "false");
+    asprintf_ret = asprintf (&what, FLUSH_STOP_FORMAT, "false");
   }
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
@@ -582,7 +591,6 @@ gstc_element_properties_list (GstClient * client,
   int asprintf_ret;
   char *response;
   char *what;
-  const char *what_fmt = "/pipelines/%s/elements/%s/properties";
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != pipeline_name, GSTC_NULL_ARGUMENT);
@@ -590,7 +598,7 @@ gstc_element_properties_list (GstClient * client,
   gstc_assert_and_ret_val (NULL != properties, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != list_lenght, GSTC_NULL_ARGUMENT);
 
-  asprintf_ret = asprintf (&what, what_fmt, pipeline_name, element);
+  asprintf_ret = asprintf (&what, PIPELINE_ELEMENTS_PROPERTIES_FORMAT, pipeline_name, element);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -617,9 +625,8 @@ gstc_pipeline_inject_eos (GstClient * client, const char *pipeline_name)
   int asprintf_ret;
   char *where;
   const char *what = "eos";
-  const char *where_fmt = "/pipelines/%s/event";
 
-  asprintf_ret = asprintf (&where, where_fmt, pipeline_name);
+  asprintf_ret = asprintf (&where, PIPELINE_EVENT_FORMAT, pipeline_name);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -640,17 +647,15 @@ gstc_pipeline_seek(GstClient *client, const char *pipeline_name,
   int asprintf_ret;
   char *where;
   char *what;
-  const char *where_fmt = "/pipelines/%s/event";
-  const char *what_fmt = "seek %f %d %d %d %lld %d %lld";
   
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != pipeline_name, GSTC_NULL_ARGUMENT);
 
-  asprintf_ret = asprintf (&where, where_fmt, pipeline_name);
+  asprintf_ret = asprintf (&where, PIPELINE_EVENT_FORMAT, pipeline_name);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
-  asprintf_ret = asprintf (&what, what_fmt, rate, format, flags, start_type, start, stop_type, stop);
+  asprintf_ret = asprintf (&what, SEEK_FORMAT, rate, format, flags, start_type, start, stop_type, stop);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -671,14 +676,13 @@ gstc_pipeline_list_elements (GstClient * client,
   int asprintf_ret;
   char *response;
   char *what;
-  const char *what_fmt = "/pipelines/%s/elements/";
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != pipeline_name, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != elements, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != list_lenght, GSTC_NULL_ARGUMENT);
 
-  asprintf_ret = asprintf (&what, what_fmt, pipeline_name);
+  asprintf_ret = asprintf (&what, PIPELINE_ELEMENTS_FORMAT, pipeline_name);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
@@ -707,13 +711,12 @@ gstc_bus_thread (void *user_data)
   int asprintf_ret;
   char *where;
   char *response;
-  const char *fmt = "/pipelines/%s/bus/message";
   const char *pipeline_name = data->pipeline_name;
   const char *message_name = data->message;
   long long timeout = data->timeout;
   GstClient *client = data->client;
 
-  asprintf_ret = asprintf (&where, fmt, pipeline_name);
+  asprintf_ret = asprintf (&where, PIPELINE_BUS_MSG_FORMAT, pipeline_name);
   if(asprintf_ret == PRINTF_ERROR) {
     return NULL;
   }
@@ -744,20 +747,18 @@ gstc_pipeline_bus_wait_async (GstClient * client,
   char *how_timeout;
   const char *what_timeout = "timeout";
   const char *what_types = "types";
-  const char *where_fmt = "/pipelines/%s/bus/%s";
-  const char *how_timeout_fmt = "%lli";
 
-  asprintf_ret = asprintf (&where_timeout, where_fmt, pipeline_name, what_timeout);
+  asprintf_ret = asprintf (&where_timeout, PIPELINE_BUS_FORMAT, pipeline_name, what_timeout);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
 
-  asprintf_ret = asprintf (&how_timeout, how_timeout_fmt, timeout);
+  asprintf_ret = asprintf (&how_timeout, TIMEOUT_FORMAT, timeout);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }
 
-  asprintf_ret = asprintf (&where_types, where_fmt, pipeline_name, what_types);
+  asprintf_ret = asprintf (&where_types, PIPELINE_BUS_FORMAT, pipeline_name, what_types);
   if(asprintf_ret == PRINTF_ERROR) {
     return GSTC_OOM;
   }

--- a/libgstc/libgstc.c
+++ b/libgstc/libgstc.c
@@ -414,6 +414,8 @@ gstc_client_debug (GstClient * client, const char *threshold,
     const int colors, const int reset)
 {
   GstcStatus ret;
+  const char * colored;
+  const char * reset_bool;
 
   gstc_assert_and_ret_val (NULL != client, GSTC_NULL_ARGUMENT);
   gstc_assert_and_ret_val (NULL != threshold, GSTC_NULL_ARGUMENT);
@@ -431,14 +433,14 @@ gstc_client_debug (GstClient * client, const char *threshold,
   }
 
   /* Enable the color in debug */
-  const char * colored = colors == 0 ? "false" : "true";
+  colored = colors == 0 ? "false" : "true";
   ret = gstc_cmd_update (client, "/debug/color", colored);
   if (ret != GSTC_OK) {
     return ret;
   }
 
   /* Set debug threshold reset */
-  const char * reset_bool = reset == 0 ? "false" : "true";
+  reset_bool = reset == 0 ? "false" : "true";
   ret = gstc_cmd_update (client, "/debug/reset", reset_bool);
   
   if (ret != GSTC_OK) {

--- a/libgstc/libgstc_socket.c
+++ b/libgstc/libgstc_socket.c
@@ -58,7 +58,7 @@ struct _GstcSocket
 };
 
 static int
-create_new_socket ()
+create_new_socket (void)
 {
   const int domain = AF_INET;
   const int type = SOCK_STREAM;

--- a/libgstc/libgstc_socket.c
+++ b/libgstc/libgstc_socket.c
@@ -45,6 +45,8 @@
 #  define GSTC_MAX_RESPONSE_LENGTH 4096
 #endif
 
+#define NUMBER_OF_SOCKETS (1)
+
 static int create_new_socket ();
 static GstcStatus open_socket(GstcSocket *self);
 
@@ -132,8 +134,7 @@ gstc_socket_send (GstcSocket * self, const char *request, char **response,
     const int timeout)
 {
   int rv;
-  const int number_of_sockets = 1;
-  struct pollfd ufds[number_of_sockets];
+  struct pollfd ufds[NUMBER_OF_SOCKETS];
   GstcStatus ret;
 
   gstc_assert_and_ret_val (NULL != self, GSTC_NULL_ARGUMENT);
@@ -157,7 +158,7 @@ gstc_socket_send (GstcSocket * self, const char *request, char **response,
   ufds[0].fd = self->socket;
   ufds[0].events = POLLIN;
   
-  rv = poll (ufds, number_of_sockets, timeout);
+  rv = poll (ufds, NUMBER_OF_SOCKETS, timeout);
 
   /* Error ocurred in poll */
   if (rv == -1) {

--- a/tests/gstd/test_gstd_no_create.c
+++ b/tests/gstd/test_gstd_no_create.c
@@ -51,6 +51,7 @@ GST_START_TEST (test_no_create)
   GstdObject *node;
   GstdReturnCode ret;
   GstdSession *test_session = gstd_session_new ("Test_session");
+  gint i;
 
   /* Create pipeline to test no create cases */
   ret = gstd_get_by_uri (test_session, "/pipelines", &node);
@@ -61,7 +62,6 @@ GST_START_TEST (test_no_create)
   fail_if (ret);
   gst_object_unref (node);
 
-  int i;
   /* Tests */
   for (i = 0; i < sizeof(target_node)/sizeof(target_node[0]); i++) {
     ret = gstd_get_by_uri (test_session, target_node[i], &node);

--- a/tests/gstd/test_gstd_session.c
+++ b/tests/gstd/test_gstd_session.c
@@ -29,7 +29,7 @@
 
 #define NUM_THREADS (3)
 
-void
+static void
 singleton_instantiation_test (void)
 {
   GstdSession *temp1 = NULL, *temp2 = NULL;
@@ -54,7 +54,7 @@ singleton_instantiation_test (void)
   g_free (name2);
 }
 
-void
+static void
 session_mem_leak_test (void)
 {
   gint reps = 10;
@@ -66,7 +66,7 @@ session_mem_leak_test (void)
 
 
 
-void *
+static void *
 instantiate_session_singleton (gpointer address)
 {
   GstdSession **sessionAdress = (GstdSession **) address;
@@ -76,7 +76,7 @@ instantiate_session_singleton (gpointer address)
   return NULL;
 }
 
-void
+static void
 thread_safety_instantiation_test (void)
 {
 

--- a/tests/gstd/test_gstd_session.c
+++ b/tests/gstd/test_gstd_session.c
@@ -69,8 +69,8 @@ session_mem_leak_test (void)
 void *
 instantiate_session_singleton (gpointer address)
 {
-  g_print ("Array Adress: %p, ", address);
   GstdSession **sessionAdress = (GstdSession **) address;
+  g_print ("Array Adress: %p, ", address);
   *sessionAdress = gstd_session_new ("SessionTest");
   g_print ("GstdSession ptr: %p \n", *sessionAdress);
   return NULL;

--- a/tests/gstd/test_gstd_session.c
+++ b/tests/gstd/test_gstd_session.c
@@ -27,6 +27,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#define NUM_THREADS (3)
+
 void
 singleton_instantiation_test ()
 {
@@ -79,17 +81,16 @@ thread_safety_instantiation_test ()
 {
 
   gint reps = 10;
-  gint num_threads = 3;
   gint i, j, r;
-  GThread *threads[num_threads];
-  GstdSession *sessions[num_threads];
+  GThread *threads[NUM_THREADS];
+  GstdSession *sessions[NUM_THREADS];
 
   //We need at least 2 threads to test
-  g_assert_true (num_threads > 2);
+  g_assert_true (NUM_THREADS > 2);
 
   for (r = 0; r < reps; ++r) {
     //spawn threads
-    for (i = 0; i < num_threads; ++i) {
+    for (i = 0; i < NUM_THREADS; ++i) {
       threads[i] =
           g_thread_new ("thread", instantiate_session_singleton,
           (gpointer) & sessions[i]);
@@ -97,7 +98,7 @@ thread_safety_instantiation_test ()
 
     //wait for threads to finish
     g_thread_join (threads[0]);
-    for (j = 1; j < num_threads; ++j) {
+    for (j = 1; j < NUM_THREADS; ++j) {
       g_thread_join (threads[j]);
       //Check all singletons are the same
       g_print ("GstdSession ptr %d: %p, GstdSession ptr %d: %p \n", j - 1,
@@ -105,7 +106,7 @@ thread_safety_instantiation_test ()
       g_assert_true (sessions[j - 1] == sessions[j]);
       g_object_unref (sessions[j - 1]);
     }
-    g_object_unref (sessions[num_threads - 1]);
+    g_object_unref (sessions[NUM_THREADS - 1]);
   }
 }
 

--- a/tests/gstd/test_gstd_session.c
+++ b/tests/gstd/test_gstd_session.c
@@ -30,7 +30,7 @@
 #define NUM_THREADS (3)
 
 void
-singleton_instantiation_test ()
+singleton_instantiation_test (void)
 {
   GstdSession *temp1 = NULL, *temp2 = NULL;
   gchar *name1, *name2;
@@ -55,7 +55,7 @@ singleton_instantiation_test ()
 }
 
 void
-session_mem_leak_test ()
+session_mem_leak_test (void)
 {
   gint reps = 10;
   gint i;
@@ -77,7 +77,7 @@ instantiate_session_singleton (gpointer address)
 }
 
 void
-thread_safety_instantiation_test ()
+thread_safety_instantiation_test (void)
 {
 
   gint reps = 10;

--- a/tests/libgstc/test_libgstc_client.c
+++ b/tests/libgstc/test_libgstc_client.c
@@ -110,14 +110,14 @@ mock_malloc (size_t size)
 }
 
 void
-setup ()
+setup (void)
 {
   _use_mock_malloc = FALSE;
   _fail_socket = FALSE;
 }
 
 void
-teardown ()
+teardown (void)
 {
 }
 

--- a/tests/libgstc/test_libgstc_client.c
+++ b/tests/libgstc/test_libgstc_client.c
@@ -21,6 +21,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Mock implementation of a socket */
 typedef struct _GstcSocket

--- a/tests/libgstc/test_libgstc_debug.c
+++ b/tests/libgstc/test_libgstc_debug.c
@@ -30,7 +30,7 @@ static GstClient *_client;
 int request_count = 0;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_element_get.c
+++ b/tests/libgstc/test_libgstc_element_get.c
@@ -30,7 +30,7 @@ static GstClient *_client;
 static int json_case = 0;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_element_set.c
+++ b/tests/libgstc/test_libgstc_element_set.c
@@ -29,7 +29,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_ping.c
+++ b/tests/libgstc/test_libgstc_ping.c
@@ -29,7 +29,7 @@ static gboolean _reachable;
 static guint64 _proc_time;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_ping.c
+++ b/tests/libgstc/test_libgstc_ping.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static GstClient *_client;

--- a/tests/libgstc/test_libgstc_pipeline_bus_wait.c
+++ b/tests/libgstc/test_libgstc_pipeline_bus_wait.c
@@ -57,7 +57,7 @@ static const char *_expected_response_corrupted = "{\n\
 }";
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_bus_wait_async.c
+++ b/tests/libgstc/test_libgstc_pipeline_bus_wait_async.c
@@ -34,7 +34,7 @@ pthread_mutex_t lock;
 int socket_send_wait_time = 0;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_bus_wait_async.c
+++ b/tests/libgstc/test_libgstc_pipeline_bus_wait_async.c
@@ -26,6 +26,7 @@
 #include "libgstc_socket.h"
 #include "libgstc_thread.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[3][512];

--- a/tests/libgstc/test_libgstc_pipeline_bus_wait_async.c
+++ b/tests/libgstc/test_libgstc_pipeline_bus_wait_async.c
@@ -184,11 +184,11 @@ GST_START_TEST (test_pipeline_bus_wait_async_bus_didnt_respond)
   const gchar *expected[] = { "update /pipelines/pipe/bus/types eos",
     "update /pipelines/pipe/bus/timeout -1"
   };
+  struct timespec ts;
   /* Set the send command to wait for 1s before responding */
   socket_send_wait_time = 1;
 
   /* Mutex timeout 10ms */
-  struct timespec ts;
   clock_gettime (CLOCK_REALTIME, &ts);
   ts.tv_sec += 0;
   ts.tv_nsec += 10 * 1000000;

--- a/tests/libgstc/test_libgstc_pipeline_create.c
+++ b/tests/libgstc/test_libgstc_pipeline_create.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_create.c
+++ b/tests/libgstc/test_libgstc_pipeline_create.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_delete.c
+++ b/tests/libgstc/test_libgstc_pipeline_delete.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_delete.c
+++ b/tests/libgstc/test_libgstc_pipeline_delete.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_flush_start.c
+++ b/tests/libgstc/test_libgstc_pipeline_flush_start.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_flush_start.c
+++ b/tests/libgstc/test_libgstc_pipeline_flush_start.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_flush_stop.c
+++ b/tests/libgstc/test_libgstc_pipeline_flush_stop.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_flush_stop.c
+++ b/tests/libgstc/test_libgstc_pipeline_flush_stop.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_inject_eos.c
+++ b/tests/libgstc/test_libgstc_pipeline_inject_eos.c
@@ -29,7 +29,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_list.c
+++ b/tests/libgstc/test_libgstc_pipeline_list.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_list.c
+++ b/tests/libgstc/test_libgstc_pipeline_list.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_list_elements.c
+++ b/tests/libgstc/test_libgstc_pipeline_list_elements.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_list_elements.c
+++ b/tests/libgstc/test_libgstc_pipeline_list_elements.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_list_properties.c
+++ b/tests/libgstc/test_libgstc_pipeline_list_properties.c
@@ -134,14 +134,14 @@ gstc_json_child_string (const char * json, const char * parent_name,
 GST_START_TEST (test_pipeline_list_properties_success)
 {
   GstcStatus ret;
-  char *expected = "read /pipelines/pipe/elements/element/properties";
-  char *pipeline_name = "pipe";
-  char *element_name = "element";
+  const char *expected = "read /pipelines/pipe/elements/element/properties";
+  const char *pipeline_name = "pipe";
+  const char *element_name = "element";
   char **response;
   int array_lenght;
 
   ret =
-      gstc_element_properties_list (_client, pipeline_name, element_name,
+      gstc_element_properties_list (_client, (gchar*)pipeline_name, (gchar*)element_name,
       &response, &array_lenght);
 
   assert_equals_int (GSTC_OK, ret);
@@ -155,12 +155,12 @@ GST_START_TEST (test_pipeline_list_properties_null_list_lenght)
 {
   GstcStatus ret;
   char **response;
-  char *pipeline_name = "pipe";
-  char *element_name = "element";
+  const char *pipeline_name = "pipe";
+  const char *element_name = "element";
   int *array_lenght = NULL;
 
   ret =
-      gstc_element_properties_list (_client, pipeline_name, element_name,
+      gstc_element_properties_list (_client, (gchar*)pipeline_name, (gchar*)element_name,
       &response, array_lenght);
 
   assert_equals_int (GSTC_NULL_ARGUMENT, ret);
@@ -172,12 +172,12 @@ GST_START_TEST (test_pipeline_list_properties_null_client)
 {
   GstcStatus ret;
   char **response;
-  char *pipeline_name = "pipe";
-  char *element_name = "element";
+  const char *pipeline_name = "pipe";
+  const char *element_name = "element";
   int array_lenght;
 
   ret =
-      gstc_element_properties_list (NULL, pipeline_name, element_name,
+      gstc_element_properties_list (NULL, (gchar*)pipeline_name, (gchar*)element_name,
       &response, &array_lenght);
 
   assert_equals_int (GSTC_NULL_ARGUMENT, ret);
@@ -190,11 +190,11 @@ GST_START_TEST (test_pipeline_list_properties_null_pipeline_name)
   GstcStatus ret;
   char **response;
   char *pipeline_name = NULL;
-  char *element_name = "element";
+  const char *element_name = "element";
   int array_lenght;
 
   ret =
-      gstc_element_properties_list (_client, pipeline_name, element_name,
+      gstc_element_properties_list (_client, pipeline_name, (gchar*)element_name,
       &response, &array_lenght);
 
   assert_equals_int (GSTC_NULL_ARGUMENT, ret);
@@ -206,12 +206,12 @@ GST_START_TEST (test_pipeline_list_properties_null_element_name)
 {
   GstcStatus ret;
   char **response;
-  char *pipeline_name = "pipe";
+  const char *pipeline_name = "pipe";
   char *element_name = NULL;
   int array_lenght;
 
   ret =
-      gstc_element_properties_list (_client, pipeline_name, element_name,
+      gstc_element_properties_list (_client, (gchar*)pipeline_name, element_name,
       &response, &array_lenght);
 
   assert_equals_int (GSTC_NULL_ARGUMENT, ret);

--- a/tests/libgstc/test_libgstc_pipeline_list_properties.c
+++ b/tests/libgstc/test_libgstc_pipeline_list_properties.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_list_properties.c
+++ b/tests/libgstc/test_libgstc_pipeline_list_properties.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_pause.c
+++ b/tests/libgstc/test_libgstc_pipeline_pause.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_pause.c
+++ b/tests/libgstc/test_libgstc_pipeline_pause.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_play.c
+++ b/tests/libgstc/test_libgstc_pipeline_play.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_play.c
+++ b/tests/libgstc/test_libgstc_pipeline_play.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_seek.c
+++ b/tests/libgstc/test_libgstc_pipeline_seek.c
@@ -29,7 +29,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_pipeline_stop.c
+++ b/tests/libgstc/test_libgstc_pipeline_stop.c
@@ -22,6 +22,7 @@
 #include "libgstc.h"
 #include "libgstc_socket.h"
 #include "libgstc_assert.h"
+#include "libgstc_json.h"
 
 /* Test Fixture */
 static gchar _request[512];

--- a/tests/libgstc/test_libgstc_pipeline_stop.c
+++ b/tests/libgstc/test_libgstc_pipeline_stop.c
@@ -28,7 +28,7 @@ static gchar _request[512];
 static GstClient *_client;
 
 static void
-setup ()
+setup (void)
 {
   const gchar *address = "";
   unsigned int port = 0;

--- a/tests/libgstc/test_libgstc_socket.c
+++ b/tests/libgstc/test_libgstc_socket.c
@@ -81,7 +81,7 @@ mock_server_thread (gpointer data)
 }
 
 static void
-mock_server_new ()
+mock_server_new (void)
 {
   GError *error = NULL;
   gint64 start_time;
@@ -118,7 +118,7 @@ mock_server_new ()
 }
 
 static void
-mock_server_free ()
+mock_server_free (void)
 {
   g_socket_service_stop (_mock_server);
   g_object_unref (_mock_server);
@@ -143,7 +143,7 @@ mock_malloc (gsize size)
 }
 
 void
-setup ()
+setup (void)
 {
   socket_delay = 0;
   _mock_malloc_oom = FALSE;
@@ -151,7 +151,7 @@ setup ()
 }
 
 void
-teardown ()
+teardown (void)
 {
   mock_server_free ();
 }


### PR DESCRIPTION
Changes applied to remove warnings generated when are added these flags:

-   -Wmissing-declarations
-   -Wmissing-prototypes
-   -Wredundant-decls
-   -Wundef
-   -Wwrite-strings
-   -Wformat
-   -Wformat-nonliteral
-   -Wformat-security
-   -Wold-style-definition
-   -Winit-self
-   -Wmissing-include-dirs
-   -Waddress
-   -Waggregate-return
-   -Wno-multichar
-   -Wdeclaration-after-statement
-   -Wvla
-   -Wpointer-arith