### PR TITLE
Feature/add pipeline position

### DIFF
--- a/gstd/gstd_pipeline.c
+++ b/gstd/gstd_pipeline.c
@@ -174,17 +174,17 @@ gstd_pipeline_class_init (GstdPipelineClass * klass)
    properties[PROP_POSITION] =
       g_param_spec_int64 ("position", "Position",
       "The query position of the pipeline",
-      0, /* Min value */
+      G_GINT64_CONSTANT(0), /* Min value */
       G_MAXINT64,
-      0, /* Default value */
+      G_GINT64_CONSTANT(0), /* Default value */
       G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
     properties[PROP_DURATION] =
       g_param_spec_int64 ("duration", "Duration",
       "The duration of the media stream pipeline",
-      0, /* Min value */
+      G_GINT64_CONSTANT(0), /* Min value */
       G_MAXINT64,
-      0, /* Default value */
+      G_GINT64_CONSTANT(0), /* Default value */
       G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
@@ -332,7 +332,7 @@ gstd_pipeline_get_property (GObject * object,
     case PROP_POSITION:
       if (!gst_element_query_position (self->pipeline, GST_FORMAT_TIME, &self->position)) {
         /* if the query could not be performed. return 0 */
-        self->position = 0;
+        self->position = G_GINT64_CONSTANT(0);
       }
 
       GST_DEBUG_OBJECT (self, "Returning pipeline position %" GST_TIME_FORMAT,
@@ -342,7 +342,7 @@ gstd_pipeline_get_property (GObject * object,
     case PROP_DURATION:
       if (!gst_element_query_duration (self->pipeline, GST_FORMAT_TIME, &self->duration)) {
         /* if the query could not be performed. return 0 */
-        self->duration = 0;
+        self->duration = G_GINT64_CONSTANT(0);
       }
 
       GST_DEBUG_OBJECT (self, "Returning pipeline duration %" GST_TIME_FORMAT,

--- a/gstd/gstd_pipeline.c
+++ b/gstd/gstd_pipeline.c
@@ -174,7 +174,7 @@ gstd_pipeline_class_init (GstdPipelineClass * klass)
    properties[PROP_POSITION] =
       g_param_spec_int64 ("position", "Position",
       "The query position of the pipeline",
-      -1, /* Min value (-1 is used to indicate error, normal range 0 to G_MAXINT64 */
+      0, /* Min value */
       G_MAXINT64,
       0, /* Default value */
       G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
@@ -182,7 +182,7 @@ gstd_pipeline_class_init (GstdPipelineClass * klass)
     properties[PROP_DURATION] =
       g_param_spec_int64 ("duration", "Duration",
       "The duration of the media stream pipeline",
-      -1, /* Min value (-1 is used to indicate error, normal range 0 to G_MAXINT64 */
+      0, /* Min value */
       G_MAXINT64,
       0, /* Default value */
       G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
@@ -296,14 +296,6 @@ gstd_pipeline_dispose (GObject * object)
     self->elements = NULL;
   }
 
-  if (self->position) {
-    self->position = 0;
-  }
-
-  if (self->duration) {
-    self->duration = 0;
-  }
-
   G_OBJECT_CLASS (gstd_pipeline_parent_class)->dispose (object);
 }
 
@@ -339,8 +331,8 @@ gstd_pipeline_get_property (GObject * object,
       break;
     case PROP_POSITION:
       if (!gst_element_query_position (self->pipeline, GST_FORMAT_TIME, &self->position)) {
-        /* if the query could not be performed. return -1 */
-        self->position = -1;
+        /* if the query could not be performed. return 0 */
+        self->position = 0;
       }
 
       GST_DEBUG_OBJECT (self, "Returning pipeline position %" GST_TIME_FORMAT,
@@ -349,8 +341,8 @@ gstd_pipeline_get_property (GObject * object,
       break;
     case PROP_DURATION:
       if (!gst_element_query_duration (self->pipeline, GST_FORMAT_TIME, &self->duration)) {
-        /* if the query could not be performed. return -1 */
-        self->duration = -1;
+        /* if the query could not be performed. return 0 */
+        self->duration = 0;
       }
 
       GST_DEBUG_OBJECT (self, "Returning pipeline duration %" GST_TIME_FORMAT,

--- a/gstd/gstd_pipeline.c
+++ b/gstd/gstd_pipeline.c
@@ -318,7 +318,6 @@ gstd_pipeline_get_property (GObject * object,
     case PROP_PIPELINE_BUS:
       GST_DEBUG_OBJECT (self, "Returning pipeline bus %p", self->pipeline_bus);
       g_value_set_object (value, self->pipeline_bus);
-      // g_value_set_object (value, self->elements);
       break;
     case PROP_STATE:
       GST_DEBUG_OBJECT (self, "Returning pipeline state %p", self->state);


### PR DESCRIPTION
# Instructions

### Create transport stream file

```
gst-launch-1.0 videotestsrc is-live=true num-buffers=10000 ! x264enc ! queue ! mpegtsmux name=mux ! filesink location=test.ts
```
### Run Daemon 
```
GST_DEBUG=*pipeline*:7 ./build/gstd/gstd-1.0 -D
```
### Run gstd client

```
gst-client pipeline_create p0 filesrc location=test.ts ! queue ! tsdemux name=tsdemuxremote ! capsfilter caps=video/x-h264,framerate=30/1 name=capsfilterremote ! queue !   h264parse ! rtph264pay timestamp-offset=0 pt=96 ssrc=0 seqnum-offset=0 ! queue ! udpsink sync=true qos=false enable-last-sample=false  

gst-client pipeline_play p0
#Get video position
gst-client read /pipelines/p0/position
#Get video duration
gst-client read /pipelines/p0/duration

```


