### PR TITLE
gstd-element: Verify that element's childs are GstObject

### DIFF
--- a/gstd/gstd_element.c
+++ b/gstd/gstd_element.c
@@ -501,7 +501,7 @@ gstd_element_fill_child_properties (GstdElement * self, GstObject * element,
 
   for (i = 0; i < count; i++) {
     child = gst_child_proxy_get_child_by_index (GST_CHILD_PROXY (element), i);
-    if (!child)
+    if (!child || !GST_IS_OBJECT(child))
       continue;
 
     if (hierarchy)


### PR DESCRIPTION
Child proxy and gstd elements list expect that its elements
have a name to accesss them, GstObject is the minimal Object
that includes this option in its structure.