### PR TITLE
Feature/improve pygstc logger

### DIFF
--- a/libgstc/Makefile.am
+++ b/libgstc/Makefile.am
@@ -20,4 +20,4 @@ noinst_HEADERS = \
 	libgstc_thread.h
 
 install-am:
-	@sudo -H pip install .
+	@sudo -H pip3 install .

--- a/libgstc/pygstc/gstc.py
+++ b/libgstc/pygstc/gstc.py
@@ -30,7 +30,6 @@
 
 import inspect
 import json
-import psutil
 import traceback
 
 from pygstc.gstcerror import *

--- a/libgstc/pygstc/logger.py
+++ b/libgstc/pygstc/logger.py
@@ -154,9 +154,10 @@ class CustomLogger:
 
         numeric_level = getattr(logging, loglevel.upper(), None)
         if isinstance(numeric_level, int):
-            self._log.setLevel(numeric_level)
+            self._log_level = numeric_level
         else:
-            self._log.setLevel(logging.ERROR)
+            self._log_level = logging.ERROR
+        self._log.setLevel(self._log_level)
         self._logger.addHandler(self._log)
 
     def __del__(self):
@@ -167,6 +168,30 @@ class CustomLogger:
         if self._log:
             self._log.close()
             self._logger.removeHandler(self._log)
+
+    def set_handler(self, handler):
+        """
+        Changes the default file or console handler to a custom one passed as a
+        parameter.
+
+        Parameters
+        ----------
+        handler : object
+            The logging handler to use
+        """
+
+        # Remove the previous handler
+
+        self._log.close()
+        self._logger.removeHandler(self._log)
+
+        # Add the new handler
+
+        self._log = handler
+        self._log.setFormatter(ColorFormatter(
+            '%(asctime)22s  %(levelname)s    \t%(message)s'))
+        self._log.setLevel(self._log_level)
+        self._logger.addHandler(self._log)
 
     def warning(self, log):
         """

--- a/libgstc/pygstc/logger.py
+++ b/libgstc/pygstc/logger.py
@@ -96,6 +96,9 @@ class CustomLogger:
 
     Methods
     ----------
+    set_handler(handler)
+        Changes the default file or console handler to a custom one passed as a
+        parameter.
     warning(log)
         Logs a warning level message
     info(log)

--- a/libgstc/setup.py
+++ b/libgstc/setup.py
@@ -33,7 +33,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pygstc',
-    version='0.1.0',
+    version='0.2.0',
     description='Python GStreamer Daemon Client',
     long_description='Python GStreamer Daemon Client',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Adds `set_handler` function to change the default handler of pygstc logger.
- Change `pip` to `pip3` in the makefile
- Clean pygstc imports (Fixes #85)