### PR TITLE
Create a JSON formatter in each function

### DIFF
--- a/gstd/gstd_bus_msg.c
+++ b/gstd/gstd_bus_msg.c
@@ -28,7 +28,6 @@
 #include "gstd_bus_msg_simple.h"
 #include "gstd_bus_msg_state_changed.h"
 #include "gstd_bus_msg_stream_status.h"
-#include "gstd_json_builder.h"
 
 /* Gstd Bus Msg debugging category */
 GST_DEBUG_CATEGORY_STATIC (gstd_bus_msg_debug);
@@ -137,7 +136,7 @@ gstd_bus_msg_to_string (GstdObject * object, gchar ** outstring)
   GstMessage *target;
   gchar *ts;
   GValue value = G_VALUE_INIT;
-  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
+  GstdIFormatter *formatter = g_object_new (object->formatter_factory, NULL);
 
   g_return_val_if_fail (object, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (outstring, GSTD_NULL_ARGUMENT);

--- a/gstd/gstd_bus_msg.c
+++ b/gstd/gstd_bus_msg.c
@@ -28,6 +28,7 @@
 #include "gstd_bus_msg_simple.h"
 #include "gstd_bus_msg_state_changed.h"
 #include "gstd_bus_msg_stream_status.h"
+#include "gstd_json_builder.h"
 
 /* Gstd Bus Msg debugging category */
 GST_DEBUG_CATEGORY_STATIC (gstd_bus_msg_debug);
@@ -136,6 +137,7 @@ gstd_bus_msg_to_string (GstdObject * object, gchar ** outstring)
   GstMessage *target;
   gchar *ts;
   GValue value = G_VALUE_INIT;
+  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
 
   g_return_val_if_fail (object, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (outstring, GSTD_NULL_ARGUMENT);
@@ -145,33 +147,33 @@ gstd_bus_msg_to_string (GstdObject * object, gchar ** outstring)
   g_return_val_if_fail (self->target, GSTD_MISSING_INITIALIZATION);
   target = self->target;
 
-  gstd_iformatter_begin_object (object->formatter);
-  gstd_iformatter_set_member_name (object->formatter, "type");
-  gstd_iformatter_set_string_value (object->formatter,
-      GST_MESSAGE_TYPE_NAME (target));
+  gstd_iformatter_begin_object (formatter);
+  gstd_iformatter_set_member_name (formatter, "type");
+  gstd_iformatter_set_string_value (formatter, GST_MESSAGE_TYPE_NAME (target));
 
-  gstd_iformatter_set_member_name (object->formatter, "source");
-  gstd_iformatter_set_string_value (object->formatter,
-      GST_MESSAGE_SRC_NAME (target));
+  gstd_iformatter_set_member_name (formatter, "source");
+  gstd_iformatter_set_string_value (formatter, GST_MESSAGE_SRC_NAME (target));
 
   ts = g_strdup_printf ("%" GST_TIME_FORMAT, GST_TIME_ARGS (target->timestamp));
-  gstd_iformatter_set_member_name (object->formatter, "timestamp");
-  gstd_iformatter_set_string_value (object->formatter, ts);
+  gstd_iformatter_set_member_name (formatter, "timestamp");
+  gstd_iformatter_set_string_value (formatter, ts);
   g_free (ts);
 
   g_value_init (&value, G_TYPE_INT);
   g_value_set_int (&value, target->seqnum);
-  gstd_iformatter_set_member_name (object->formatter, "seqnum");
-  gstd_iformatter_set_value (object->formatter, &value);
+  gstd_iformatter_set_member_name (formatter, "seqnum");
+  gstd_iformatter_set_value (formatter, &value);
   g_value_unset (&value);
 
   if (GSTD_BUS_MSG_GET_CLASS (self)->to_string) {
-    GSTD_BUS_MSG_GET_CLASS (self)->to_string (self, object->formatter, target);
+    GSTD_BUS_MSG_GET_CLASS (self)->to_string (self, formatter, target);
   }
 
-  gstd_iformatter_end_object (object->formatter);
+  gstd_iformatter_end_object (formatter);
 
-  gstd_iformatter_generate (object->formatter, outstring);
+  gstd_iformatter_generate (formatter, outstring);
 
+  /* Free formatter */
+  g_object_unref (formatter);
   return GSTD_EOK;
 }

--- a/gstd/gstd_callback.c
+++ b/gstd/gstd_callback.c
@@ -22,7 +22,6 @@
 #endif
 
 #include "gstd_callback.h"
-#include "gstd_json_builder.h"
 
 /* Gstd Bus Msg debugging category */
 GST_DEBUG_CATEGORY_STATIC (gstd_callback_debug);
@@ -94,7 +93,7 @@ gstd_callback_to_string (GstdObject * object, gchar ** outstring)
 {
   GstdCallback *self;
   guint i;
-  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
+  GstdIFormatter *formatter = g_object_new (object->formatter_factory, NULL);
 
   g_return_val_if_fail (object, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (outstring, GSTD_NULL_ARGUMENT);

--- a/gstd/gstd_callback.c
+++ b/gstd/gstd_callback.c
@@ -22,6 +22,7 @@
 #endif
 
 #include "gstd_callback.h"
+#include "gstd_json_builder.h"
 
 /* Gstd Bus Msg debugging category */
 GST_DEBUG_CATEGORY_STATIC (gstd_callback_debug);
@@ -93,6 +94,7 @@ gstd_callback_to_string (GstdObject * object, gchar ** outstring)
 {
   GstdCallback *self;
   guint i;
+  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
 
   g_return_val_if_fail (object, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (outstring, GSTD_NULL_ARGUMENT);
@@ -101,30 +103,32 @@ gstd_callback_to_string (GstdObject * object, gchar ** outstring)
 
   GST_DEBUG_OBJECT (self, "Callback to string %p", object);
 
-  gstd_iformatter_begin_object (object->formatter);
-  gstd_iformatter_set_member_name (object->formatter, "name");
-  gstd_iformatter_set_string_value (object->formatter, self->signal_name);
+  gstd_iformatter_begin_object (formatter);
+  gstd_iformatter_set_member_name (formatter, "name");
+  gstd_iformatter_set_string_value (formatter, self->signal_name);
 
-  gstd_iformatter_set_member_name (object->formatter, "arguments");
-  gstd_iformatter_begin_array (object->formatter);
+  gstd_iformatter_set_member_name (formatter, "arguments");
+  gstd_iformatter_begin_array (formatter);
 
   for (i = 0; i < self->n_params; i++) {
-    gstd_iformatter_begin_object (object->formatter);
-    gstd_iformatter_set_member_name (object->formatter, "type");
-    gstd_iformatter_set_string_value (object->formatter,
+    gstd_iformatter_begin_object (formatter);
+    gstd_iformatter_set_member_name (formatter, "type");
+    gstd_iformatter_set_string_value (formatter,
         G_VALUE_TYPE_NAME (&self->param_values[i]));
 
-    gstd_iformatter_set_member_name (object->formatter, "value");
-    gstd_iformatter_set_value (object->formatter, &self->param_values[i]);
-    gstd_iformatter_end_object (object->formatter);
+    gstd_iformatter_set_member_name (formatter, "value");
+    gstd_iformatter_set_value (formatter, &self->param_values[i]);
+    gstd_iformatter_end_object (formatter);
   }
 
-  gstd_iformatter_end_array (object->formatter);
+  gstd_iformatter_end_array (formatter);
 
-  gstd_iformatter_end_object (object->formatter);
+  gstd_iformatter_end_object (formatter);
 
-  gstd_iformatter_generate (object->formatter, outstring);
+  gstd_iformatter_generate (formatter, outstring);
 
+  /* Free formatter */
+  g_object_unref (formatter);
   return GSTD_EOK;
 }
 

--- a/gstd/gstd_object.c
+++ b/gstd/gstd_object.c
@@ -126,6 +126,7 @@ gstd_object_init (GstdObject * self)
   self->reader = g_object_new (GSTD_TYPE_NO_READER, NULL);
   self->updater = g_object_new (GSTD_TYPE_NO_UPDATER, NULL);
   self->deleter = g_object_new (GSTD_TYPE_NO_DELETER, NULL);
+  self->formatter_factory = GSTD_TYPE_JSON_BUILDER;
 }
 
 void
@@ -264,7 +265,7 @@ gstd_object_to_string_default (GstdObject * self, gchar ** outstring)
   gchar *sflags;
   guint n, i;
   const gchar *typename;
-  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
+  GstdIFormatter *formatter = g_object_new (self->formatter_factory, NULL);
 
   gstd_iformatter_begin_object (formatter);
   gstd_iformatter_set_member_name (formatter, "properties");

--- a/gstd/gstd_object.h
+++ b/gstd/gstd_object.h
@@ -70,6 +70,7 @@ struct _GstdObject
   GstdIUpdater *updater;
   GstdIDeleter *deleter;
 
+  GType formatter_factory;
 };
 
 #define GSTD_OBJECT_NAME(obj) (GSTD_OBJECT(obj)->name)

--- a/gstd/gstd_object.h
+++ b/gstd/gstd_object.h
@@ -70,7 +70,6 @@ struct _GstdObject
   GstdIUpdater *updater;
   GstdIDeleter *deleter;
 
-  GstdIFormatter *formatter;
 };
 
 #define GSTD_OBJECT_NAME(obj) (GSTD_OBJECT(obj)->name)

--- a/gstd/gstd_property.c
+++ b/gstd/gstd_property.c
@@ -22,7 +22,6 @@
 #endif
 
 #include "gstd_property.h"
-#include "gstd_json_builder.h"
 
 enum
 {
@@ -183,7 +182,7 @@ gstd_property_to_string (GstdObject * obj, gchar ** outstring)
   GValue value = G_VALUE_INIT;
   gchar *sflags;
   const gchar *typename;
-  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
+  GstdIFormatter *formatter = g_object_new (obj->formatter_factory, NULL);
 
   g_return_val_if_fail (GSTD_IS_OBJECT (obj), GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (outstring, GSTD_NULL_ARGUMENT);

--- a/gstd/gstd_state.c
+++ b/gstd/gstd_state.c
@@ -24,7 +24,6 @@
 
 #include <gst/gst.h>
 #include "gstd_state.h"
-#include "gstd_json_builder.h"
 
 enum
 {
@@ -118,7 +117,7 @@ gstd_state_to_string (GstdObject * obj, gchar ** outstring)
   GValue value = G_VALUE_INIT;
   gchar *svalue;
   const gchar *typename;
-  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
+  GstdIFormatter *formatter = g_object_new (obj->formatter_factory, NULL);
 
   g_return_val_if_fail (GSTD_IS_OBJECT (obj), GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (outstring, GSTD_NULL_ARGUMENT);

--- a/gstd/gstd_state.c
+++ b/gstd/gstd_state.c
@@ -24,6 +24,7 @@
 
 #include <gst/gst.h>
 #include "gstd_state.h"
+#include "gstd_json_builder.h"
 
 enum
 {
@@ -117,6 +118,7 @@ gstd_state_to_string (GstdObject * obj, gchar ** outstring)
   GValue value = G_VALUE_INIT;
   gchar *svalue;
   const gchar *typename;
+  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
 
   g_return_val_if_fail (GSTD_IS_OBJECT (obj), GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (outstring, GSTD_NULL_ARGUMENT);
@@ -124,12 +126,12 @@ gstd_state_to_string (GstdObject * obj, gchar ** outstring)
   self = GSTD_STATE (obj);
 
   /* Describe each parameter using a structure */
-  gstd_iformatter_begin_object (obj->formatter);
+  gstd_iformatter_begin_object (formatter);
 
-  gstd_iformatter_set_member_name (obj->formatter, "name");
-  gstd_iformatter_set_string_value (obj->formatter, GSTD_OBJECT_NAME (self));
+  gstd_iformatter_set_member_name (formatter, "name");
+  gstd_iformatter_set_string_value (formatter, GSTD_OBJECT_NAME (self));
 
-  gstd_iformatter_set_member_name (obj->formatter, "value");
+  gstd_iformatter_set_member_name (formatter, "value");
 
   /* The state of the pipeline might have changed autonomously,
      refresh the value */
@@ -138,41 +140,42 @@ gstd_state_to_string (GstdObject * obj, gchar ** outstring)
   g_value_init (&value, GSTD_TYPE_STATE_ENUM);
   g_value_set_enum (&value, self->state);
   svalue = gst_value_serialize (&value);
-  gstd_iformatter_set_string_value (obj->formatter, svalue);
+  gstd_iformatter_set_string_value (formatter, svalue);
 
   g_free (svalue);
   g_value_unset (&value);
 
-  gstd_iformatter_set_member_name (obj->formatter, "param");
+  gstd_iformatter_set_member_name (formatter, "param");
   /* Describe the parameter specs using a structure */
-  gstd_iformatter_begin_object (obj->formatter);
+  gstd_iformatter_begin_object (formatter);
 
-  gstd_iformatter_set_member_name (obj->formatter, "description");
-  gstd_iformatter_set_string_value (obj->formatter,
-      "The state of the pipeline");
+  gstd_iformatter_set_member_name (formatter, "description");
+  gstd_iformatter_set_string_value (formatter, "The state of the pipeline");
 
   typename = g_type_name (GSTD_TYPE_STATE_ENUM);
-  gstd_iformatter_set_member_name (obj->formatter, "type");
-  gstd_iformatter_set_string_value (obj->formatter, typename);
+  gstd_iformatter_set_member_name (formatter, "type");
+  gstd_iformatter_set_string_value (formatter, typename);
 
   g_value_init (&value, GSTD_TYPE_PARAM_FLAGS);
   g_value_set_flags (&value, G_PARAM_READWRITE);
   svalue = g_strdup_value_contents (&value);
   g_value_unset (&value);
 
-  gstd_iformatter_set_member_name (obj->formatter, "access");
-  gstd_iformatter_set_string_value (obj->formatter, svalue);
+  gstd_iformatter_set_member_name (formatter, "access");
+  gstd_iformatter_set_string_value (formatter, svalue);
 
   g_free (svalue);
 
   /* Close parameter specs structure */
-  gstd_iformatter_end_object (obj->formatter);
+  gstd_iformatter_end_object (formatter);
 
   /* Close parameter structure */
-  gstd_iformatter_end_object (obj->formatter);
+  gstd_iformatter_end_object (formatter);
 
-  gstd_iformatter_generate (obj->formatter, outstring);
+  gstd_iformatter_generate (formatter, outstring);
 
+  /* Free formatter */
+  g_object_unref (formatter);
   return GSTD_EOK;
 }
 


### PR DESCRIPTION
Using a global gstd JSON formater created once in gstd object
was causing a race condition for the JsonBuilder in GstdJsonBuilder
struct. By creating a JSON formatter in each function we avoid
the race condition without adding mutex.