### PR TITLE
Add a thread safe support for GstdList

### DIFF
--- a/gstd/gstd_list.h
+++ b/gstd/gstd_list.h
@@ -58,8 +58,6 @@ struct _GstdList
   GParamFlags flags;
 
   GList *list;
-
-  GMutex mutex;
 };
 
 struct _GstdListClass

--- a/gstd/gstd_list.h
+++ b/gstd/gstd_list.h
@@ -58,6 +58,8 @@ struct _GstdList
   GParamFlags flags;
 
   GList *list;
+
+  GMutex mutex;
 };
 
 struct _GstdListClass


### PR DESCRIPTION
A GstdList being accessed by multiple threads is observed. However the implementation of the GstdList class is not thread safe. The result of my analysis is as bellow.

https://github.com/RidgeRun/EdgeStream/issues/477#issuecomment-766807111

Actually there are cases in which a crash that is assumed to be caused by a race condition due to that occurs in GstdList. The following stack trace is observed when the crash occurs.

https://github.com/RidgeRun/EdgeStream/issues/477#issuecomment-765335530

This change protects critical sections in the GstList implementation with mutex locks, then we can confirm that the crash as above does not occur through a long run test for several hours.
