### PR TITLE
Feature/pipeline commands reference count

### DIFF
--- a/gstd/Makefile.am
+++ b/gstd/Makefile.am
@@ -53,7 +53,8 @@ libgstd_core_la_SOURCES = gstd_session.c		\
 			  gstd_signal_reader.c		\
 			  gstd_socket.c			\
 			  gstd_unix.c			\
-			  gstd_signal_list.c
+			  gstd_signal_list.c    \
+			  gstd_refcount.c
 
 libgstd_core_la_CFLAGS = $(GST_CFLAGS)					\
 			 $(GIO_CFLAGS)					\
@@ -135,7 +136,8 @@ gstdinclude_HEADERS = \
 		  gstd_log.h			\
 		  gstd_bus_msg_stream_status.h	\
 		  gstd_bus_msg_element.h	\
-		  gstd_signal_list.h
+		  gstd_signal_list.h	\
+		  gstd_refcount.h
 
 noinst_HEADERS = gstd_daemon.h
 

--- a/gstd/gstd_http.c
+++ b/gstd/gstd_http.c
@@ -27,6 +27,7 @@
 #include <libsoup/soup.h>
 
 #include "gstd_http.h"
+#include "gstd_parser.h"
 
 /* Gstd HTTP debugging category */
 GST_DEBUG_CATEGORY_STATIC (gstd_http_debug);

--- a/gstd/gstd_ipc.h
+++ b/gstd/gstd_ipc.h
@@ -57,7 +57,6 @@
 #include "gstd_object.h"
 #include "gstd_pipeline.h"
 #include "gstd_session.h"
-#include "gstd_parser.h"
 
 G_BEGIN_DECLS
 #define GSTD_TYPE_IPC \

--- a/gstd/gstd_parser.c
+++ b/gstd/gstd_parser.c
@@ -1,6 +1,6 @@
 /*
  * GStreamer Daemon - Gst Launch under steroids
- * Copyright (c) 2015-2020 Ridgerun, LLC (http://www.ridgerun.com)
+ * Copyright (c) 2015-2021 Ridgerun, LLC (http://www.ridgerun.com)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -95,6 +95,14 @@ static GstdReturnCode gstd_parser_debug_color (GstdSession *, gchar *, gchar *,
     gchar **);
 static GstdReturnCode gstd_parser_debug_reset (GstdSession *, gchar *, gchar *,
     gchar **);
+static GstdReturnCode gstd_parser_pipeline_create_ref (GstdSession *, gchar *,
+    gchar *, gchar **);
+static GstdReturnCode gstd_parser_pipeline_delete_ref (GstdSession *, gchar *,
+    gchar *, gchar **);
+static GstdReturnCode gstd_parser_pipeline_play_ref (GstdSession *, gchar *,
+    gchar *, gchar **);
+static GstdReturnCode gstd_parser_pipeline_stop_ref (GstdSession *, gchar *,
+    gchar *, gchar **);
 
 typedef GstdReturnCode GstdFunc (GstdSession *, gchar *, gchar *, gchar **);
 typedef struct _GstdCmd
@@ -142,6 +150,11 @@ static GstdCmd cmds[] = {
   {"debug_threshold", gstd_parser_debug_threshold},
   {"debug_color", gstd_parser_debug_color},
   {"debug_reset", gstd_parser_debug_reset},
+
+  {"pipeline_create_ref", gstd_parser_pipeline_create_ref},
+  {"pipeline_delete_ref", gstd_parser_pipeline_delete_ref},
+  {"pipeline_play_ref", gstd_parser_pipeline_play_ref},
+  {"pipeline_stop_ref", gstd_parser_pipeline_stop_ref},
 
   {NULL}
 };
@@ -935,6 +948,75 @@ gstd_parser_signal_timeout (GstdSession * session, gchar * action, gchar * args,
 
   g_free (uri);
   g_strfreev (tokens);
+
+  return ret;
+}
+
+static GstdReturnCode
+gstd_parser_pipeline_create_ref (GstdSession * session, gchar * action,
+    gchar * args, gchar ** response)
+{
+  GstdReturnCode ret;
+  gchar *uri;
+
+  g_return_val_if_fail (GSTD_IS_SESSION (session), GSTD_NULL_ARGUMENT);
+
+  uri = g_strdup_printf ("/pipelines %s", args ? args : "");
+
+  ret = gstd_parser_parse_raw_cmd (session, (gchar *) "create", uri, response);
+
+  g_free (uri);
+
+  return ret;
+}
+
+static GstdReturnCode
+gstd_parser_pipeline_delete_ref (GstdSession * session, gchar * action,
+    gchar * args, gchar ** response)
+{
+  GstdReturnCode ret;
+  gchar *uri;
+
+  g_return_val_if_fail (GSTD_IS_SESSION (session), GSTD_NULL_ARGUMENT);
+  g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
+
+  uri = g_strdup_printf ("/pipelines %s", args);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar *) "delete", uri, response);
+  g_free (uri);
+
+  return ret;
+}
+
+static GstdReturnCode
+gstd_parser_pipeline_play_ref (GstdSession * session, gchar * action,
+    gchar * args, gchar ** response)
+{
+  GstdReturnCode ret;
+  gchar *uri;
+
+  g_return_val_if_fail (GSTD_IS_SESSION (session), GSTD_NULL_ARGUMENT);
+  g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
+
+  uri = g_strdup_printf ("/pipelines/%s/state playing", args);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar *) "update", uri, response);
+  g_free (uri);
+
+  return ret;
+}
+
+static GstdReturnCode
+gstd_parser_pipeline_stop_ref (GstdSession * session, gchar * action,
+    gchar * args, gchar ** response)
+{
+  GstdReturnCode ret;
+  gchar *uri;
+
+  g_return_val_if_fail (GSTD_IS_SESSION (session), GSTD_NULL_ARGUMENT);
+  g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
+
+  uri = g_strdup_printf ("/pipelines/%s/state null", args);
+  ret = gstd_parser_parse_raw_cmd (session, (gchar *) "update", uri, response);
+  g_free (uri);
 
   return ret;
 }

--- a/gstd/gstd_refcount.c
+++ b/gstd/gstd_refcount.c
@@ -1,0 +1,179 @@
+/*
+ * GStreamer Daemon - Gst Launch under steroids
+ * Copyright (c) 2021 Ridgerun, LLC (http://www.ridgerun.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include "gstd_refcount.h"
+
+/* Hash table values struct */
+typedef struct
+{
+  /**
+   * Refcount for create calls
+   */
+  guint create_refcount;
+
+  /**
+   * Refcount for play calls
+   */
+  guint play_refcount;
+} HashValue;
+
+static void gstd_refcount_finalize (GObject * object);
+static HashValue *gstd_refcount_get_hash_value (GstdRefcount * refcount,
+    gchar * key);
+
+struct _GstdRefcount
+{
+  GObject parent;
+
+  /**
+   * Hash table to keep track of the refcounts
+   */
+  GHashTable *hash;
+
+  /**
+   * Protection for object's lock
+   */
+  GMutex mutex;
+};
+
+G_DEFINE_TYPE (GstdRefcount, gstd_refcount, G_TYPE_OBJECT);
+
+static void
+gstd_refcount_class_init (GstdRefcountClass * klass)
+{
+  GObjectClass *gobject_class;
+
+  gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->finalize = gstd_refcount_finalize;
+}
+
+static void
+gstd_refcount_init (GstdRefcount * refcount)
+{
+  refcount->hash = g_hash_table_new (g_str_hash, g_str_equal);
+
+  g_mutex_init (&refcount->mutex);
+}
+
+static void
+gstd_refcount_finalize (GObject * object)
+{
+  GstdRefcount *refcount;
+
+  refcount = _GSTD_REFCOUNT (object);
+
+  g_hash_table_destroy (refcount->hash);
+
+  g_mutex_clear (&refcount->mutex);
+
+  /* Chain up to the parent class */
+  G_OBJECT_CLASS (gstd_refcount_parent_class)->finalize (object);
+}
+
+static HashValue *
+gstd_refcount_get_hash_value (GstdRefcount * refcount, gchar * key)
+{
+  HashValue *value;
+
+  if ((value = g_hash_table_lookup (refcount->hash, key)) == NULL) {
+    /* key not found */
+    value = (HashValue *) malloc (sizeof (HashValue));
+    value->create_refcount = 0;
+    value->play_refcount = 0;
+    g_hash_table_insert (refcount->hash, key, value);
+  }
+  return value;
+}
+
+guint
+gstd_refcount_get_create_refcount (GstdRefcount * refcount, gchar * key)
+{
+  HashValue *value;
+  guint create_refcount;
+
+  g_mutex_lock (&refcount->mutex);
+  value = gstd_refcount_get_hash_value (refcount, key);
+  create_refcount = value->create_refcount;
+  g_mutex_unlock (&refcount->mutex);
+
+  return create_refcount;
+}
+
+guint
+gstd_refcount_get_play_refcount (GstdRefcount * refcount, gchar * key)
+{
+  HashValue *value;
+  guint play_refcount;
+
+  g_mutex_lock (&refcount->mutex);
+  value = gstd_refcount_get_hash_value (refcount, key);
+  play_refcount = value->play_refcount;
+  g_mutex_unlock (&refcount->mutex);
+
+  return play_refcount;
+}
+
+void
+gstd_refcount_increment_create_refcount (GstdRefcount * refcount, gchar * key)
+{
+  HashValue *value;
+
+  g_mutex_lock (&refcount->mutex);
+  value = gstd_refcount_get_hash_value (refcount, key);
+  value->create_refcount++;
+  g_mutex_unlock (&refcount->mutex);
+}
+
+void
+gstd_refcount_decrement_create_refcount (GstdRefcount * refcount, gchar * key)
+{
+  HashValue *value;
+
+  g_mutex_lock (&refcount->mutex);
+  value = gstd_refcount_get_hash_value (refcount, key);
+  if (value->create_refcount > 0) {
+    value->create_refcount--;
+  }
+  g_mutex_unlock (&refcount->mutex);
+}
+
+void
+gstd_refcount_increment_play_refcount (GstdRefcount * refcount, gchar * key)
+{
+  HashValue *value;
+
+  g_mutex_lock (&refcount->mutex);
+  value = gstd_refcount_get_hash_value (refcount, key);
+  value->play_refcount++;
+  g_mutex_unlock (&refcount->mutex);
+}
+
+void
+gstd_refcount_decrement_play_refcount (GstdRefcount * refcount, gchar * key)
+{
+  HashValue *value;
+
+  g_mutex_lock (&refcount->mutex);
+  value = gstd_refcount_get_hash_value (refcount, key);
+  if (value->play_refcount > 0) {
+    value->play_refcount--;
+  }
+  g_mutex_unlock (&refcount->mutex);
+}

--- a/gstd/gstd_refcount.c
+++ b/gstd/gstd_refcount.c
@@ -76,9 +76,16 @@ static void
 gstd_refcount_finalize (GObject * object)
 {
   GstdRefcount *refcount;
+  GHashTableIter iter;
+  gpointer key, value;
 
   refcount = _GSTD_REFCOUNT (object);
 
+  g_hash_table_iter_init (&iter, refcount->hash);
+  while (g_hash_table_iter_next (&iter, &key, &value)) {
+    g_free (key);
+    g_free (value);
+  }
   g_hash_table_destroy (refcount->hash);
 
   g_mutex_clear (&refcount->mutex);
@@ -94,10 +101,10 @@ gstd_refcount_get_hash_value (GstdRefcount * refcount, gchar * key)
 
   if ((value = g_hash_table_lookup (refcount->hash, key)) == NULL) {
     /* key not found */
-    value = (HashValue *) malloc (sizeof (HashValue));
+    value = (HashValue *) g_malloc (sizeof (HashValue));
     value->create_refcount = 0;
     value->play_refcount = 0;
-    g_hash_table_insert (refcount->hash, key, value);
+    g_hash_table_insert (refcount->hash, g_strdup (key), value);
   }
   return value;
 }

--- a/gstd/gstd_refcount.h
+++ b/gstd/gstd_refcount.h
@@ -1,0 +1,96 @@
+/*
+ * GStreamer Daemon - Gst Launch under steroids
+ * Copyright (c) 2021 Ridgerun, LLC (http://www.ridgerun.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef __GSTD_REFCOUNT_H__
+#define __GSTD_REFCOUNT_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+#define TYPE_GSTD_REFCOUNT (gstd_refcount_get_type ())
+G_DECLARE_FINAL_TYPE (GstdRefcount, gstd_refcount,, GSTD_REFCOUNT, GObject);
+
+typedef struct _GstdRefcount GstdRefcount;
+
+/**
+ * Get the create refcount of a given key
+ *
+ * \param refcount GstdRefcount object
+ * \param key Pipeline name
+ *
+ * \return guint refcount
+ **/
+guint gstd_refcount_get_create_refcount (GstdRefcount * refcount, gchar * key);
+
+/**
+ * Get the play refcount of a given key
+ *
+ * \param refcount GstdRefcount object
+ * \param key Pipeline name
+ *
+ * \return guint refcount
+ **/
+guint gstd_refcount_get_play_refcount (GstdRefcount * refcount, gchar * key);
+
+/**
+ * Increment the create refcount of a given key
+ *
+ * \param refcount GstdRefcount object
+ * \param key Pipeline name
+ *
+ * \return void
+ **/
+void gstd_refcount_increment_create_refcount (GstdRefcount * refcount,
+    gchar * key);
+
+/**
+ * Decrement the create refcount of a given key
+ *
+ * \param refcount GstdRefcount object
+ * \param key Pipeline name
+ *
+ * \return void
+ **/
+void gstd_refcount_decrement_create_refcount (GstdRefcount * refcount,
+    gchar * key);
+
+/**
+ * Increment the play refcount of a given key
+ *
+ * \param refcount GstdRefcount object
+ * \param key Pipeline name
+ *
+ * \return void
+ **/
+void gstd_refcount_increment_play_refcount (GstdRefcount * refcount,
+    gchar * key);
+
+/**
+ * Decrement the play refcount of a given key
+ *
+ * \param refcount GstdRefcount object
+ * \param key Pipeline name
+ *
+ * \return void
+ **/
+void gstd_refcount_decrement_play_refcount (GstdRefcount * refcount,
+    gchar * key);
+
+G_END_DECLS
+#endif //__GSTD_REFCOUNT_H__

--- a/gstd/gstd_session.c
+++ b/gstd/gstd_session.c
@@ -154,6 +154,8 @@ gstd_session_init (GstdSession * self)
       GSTD_DEBUG (g_object_new (GSTD_TYPE_DEBUG, "name", "Debug", NULL));
 
   self->pid = (GPid) getpid ();
+
+  self->refcount = g_object_new (TYPE_GSTD_REFCOUNT, NULL);
 }
 
 static void
@@ -221,6 +223,11 @@ gstd_session_dispose (GObject * object)
   if (self->debug) {
     g_object_unref (self->debug);
     self->debug = NULL;
+  }
+
+  if (self->refcount) {
+    g_object_unref (self->refcount);
+    self->refcount = NULL;
   }
 
   G_OBJECT_CLASS (gstd_session_parent_class)->dispose (object);

--- a/gstd/gstd_session.h
+++ b/gstd/gstd_session.h
@@ -175,6 +175,7 @@
 #include "gstd_pipeline.h"
 #include "gstd_list.h"
 #include "gstd_debug.h"
+#include "gstd_refcount.h"
 
 G_BEGIN_DECLS
 #define GSTD_TYPE_SESSION \
@@ -210,6 +211,11 @@ struct _GstdSession
    * Object containing debug options
    */
   GstdDebug *debug;
+
+  /*
+   * Object containing the refcount utility
+   */
+  GstdRefcount *refcount;
 };
 
 struct _GstdSessionClass

--- a/gstd/gstd_socket.c
+++ b/gstd/gstd_socket.c
@@ -23,6 +23,7 @@
 
 #include <string.h>
 
+#include "gstd_parser.h"
 #include "gstd_socket.h"
 
 /* Gstd SOCKET debugging category */

--- a/gstd/gstd_tcp.c
+++ b/gstd/gstd_tcp.c
@@ -27,7 +27,6 @@
 
 #include "gstd_ipc.h"
 #include "gstd_tcp.h"
-#include "gstd_parser.h"
 #include "gstd_element.h"
 #include "gstd_pipeline_bus.h"
 #include "gstd_event_handler.h"

--- a/libgstc/python/pygstc/gstc.py
+++ b/libgstc/python/pygstc/gstc.py
@@ -829,6 +829,26 @@ class GstdClient:
         parameters = self._check_parameters([pipe_name, pipe_desc], [str, str])
         self._send_cmd_line(['pipeline_create'] + parameters)
 
+    def pipeline_create_ref(self, pipe_name, pipe_desc):
+        """
+        Create a new pipeline based on the name and description using refcount.
+        The refcount works similarly to GObject references. If the command
+        is called but the refcount is greter than 0 nothing will happen
+        and the refcount will increment.
+
+        Parameters
+        ----------
+        pipe_name: string
+            The name of the pipeline
+        pipe_desc: string
+            Pipeline description (same as gst-launch-1.0)
+        """
+
+        self._logger.info('Creating pipeline %s with description "%s"'
+                          % (pipe_name, pipe_desc))
+        parameters = self._check_parameters([pipe_name, pipe_desc], [str, str])
+        self._send_cmd_line(['pipeline_create_ref'] + parameters)
+
     def pipeline_delete(self, pipe_name):
         """
         Delete the pipeline with the given name.
@@ -849,6 +869,30 @@ class GstdClient:
         self._logger.info('Deleting pipeline %s' % pipe_name)
         parameters = self._check_parameters([pipe_name], [str])
         self._send_cmd_line(['pipeline_delete'] + parameters)
+
+    def pipeline_delete_ref(self, pipe_name):
+        """
+        Delete the pipeline with the given name using refcount.
+        The refcount works similarly to GObject references. If the command
+        is called but the refcount is greter than 1 nothing will happen
+        and the refcount will decrement.
+
+        Parameters
+        ----------
+        pipe_name: string
+            The name of the pipeline
+
+        Raises
+        ------
+        GstdError
+            Error is triggered when Gstd IPC fails
+        GstcError
+            Error is triggered when the Gstd python client fails internally
+        """
+
+        self._logger.info('Deleting pipeline %s' % pipe_name)
+        parameters = self._check_parameters([pipe_name], [str])
+        self._send_cmd_line(['pipeline_delete_ref'] + parameters)
 
     def pipeline_pause(self, pipe_name):
         """
@@ -892,6 +936,30 @@ class GstdClient:
         parameters = self._check_parameters([pipe_name], [str])
         self._send_cmd_line(['pipeline_play'] + parameters)
 
+    def pipeline_play_ref(self, pipe_name):
+        """
+        Set the pipeline to playing using refcount.
+        The refcount works similarly to GObject references. If the command
+        is called but the refcount is greter than 0 nothing will happen
+        and the refcount will increment.
+
+        Parameters
+        ----------
+        pipe_name: string
+            The name of the pipeline
+
+        Raises
+        ------
+        GstdError
+            Error is triggered when Gstd IPC fails
+        GstcError
+            Error is triggered when the Gstd python client fails internally
+        """
+
+        self._logger.info('Playing pipeline %s' % pipe_name)
+        parameters = self._check_parameters([pipe_name], [str])
+        self._send_cmd_line(['pipeline_play_ref'] + parameters)
+
     def pipeline_stop(self, pipe_name):
         """
         Set the pipeline to null.
@@ -912,6 +980,30 @@ class GstdClient:
         self._logger.info('Stoping pipeline %s' % pipe_name)
         parameters = self._check_parameters([pipe_name], [str])
         self._send_cmd_line(['pipeline_stop'] + parameters)
+
+    def pipeline_stop_ref(self, pipe_name):
+        """
+        Set the pipeline to null using refcount.
+        The refcount works similarly to GObject references. If the command
+        is called but the refcount is greter than 1 nothing will happen
+        and the refcount will decrement.
+
+        Parameters
+        ----------
+        pipe_name: string
+            The name of the pipeline
+
+        Raises
+        ------
+        GstdError
+            Error is triggered when Gstd IPC fails
+        GstcError
+            Error is triggered when the Gstd python client fails internally
+        """
+
+        self._logger.info('Stoping pipeline %s' % pipe_name)
+        parameters = self._check_parameters([pipe_name], [str])
+        self._send_cmd_line(['pipeline_stop_ref'] + parameters)
 
     def pipeline_get_graph(self, pipe_name):
         """

--- a/libgstc/python/setup.py
+++ b/libgstc/python/setup.py
@@ -33,7 +33,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pygstc',
-    version='0.2.0',
+    version='0.3.0',
     description='Python GStreamer Daemon Client',
     long_description='Python GStreamer Daemon Client',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The objective of this change is to provide thread-safe implementations of pipeline operations (create, delete, play, and stop). What we experienced with multiple GstD clients on different threads is that handling shared pipelines often leads to race conditions.

Imagine 2 threads sharing the same source pipeline. Each thread will create and delete the pipeline with something like this:
```
if (!pipeline_exists (pipeline))
  pipeline_create(pipeline)
...
if (pipeline_exists (pipeline))
  pipeline_delete(pipeline)
```
Even with serialized calls, it is possible that both threads will try to create or delete the pipeline, resulting in errors.

This solution uses the same concept as GObject's ref/unref to solve the problem. Using a hash table I keep track of the play and create refcount for each pipeline by name. Trying to create a pipeline that already exist will only increase the refcount by one, and the pipeline will only be deleted when the refcount reaches 0.

The previous example would avoid all the race conditions by using the new functions:
```
pipeline_create_ref(pipeline)
...
pipeline_delete_ref(pipeline)
```
For the time being, I only added support to these functions to the Python client.

