### PR TITLE
Fix a memory leak for gst_debug_bin_to_dot_data

### DIFF
--- a/gstd/gstd_pipeline.c
+++ b/gstd/gstd_pipeline.c
@@ -326,6 +326,7 @@ gstd_pipeline_get_property (GObject * object,
     guint property_id, GValue * value, GParamSpec * pspec)
 {
   GstdPipeline *self = GSTD_PIPELINE (object);
+  gchar *dot;
 
   switch (property_id) {
     case PROP_DESCRIPTION:
@@ -352,9 +353,10 @@ gstd_pipeline_get_property (GObject * object,
       break;
     case PROP_GRAPH:
       GST_DEBUG_OBJECT (self, "Returning graph handler %p", self->graph);
-      g_value_set_string (value,
-          gst_debug_bin_to_dot_data (GST_BIN (self->pipeline),
-              GST_DEBUG_GRAPH_SHOW_ALL));
+      dot = gst_debug_bin_to_dot_data (GST_BIN (self->pipeline),
+          GST_DEBUG_GRAPH_SHOW_ALL);
+      g_value_set_string (value, dot);
+      g_free (dot);
       break;
 
     case PROP_VERBOSE:


### PR DESCRIPTION
The returned string from gst_debug_bin_to_dot_data() should be freed because g_string_free() is used for it and we have to free it after use when FALSE is passed via its argument.

https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/1.14/gst/gstdebugutils.c#L819
https://developer.gnome.org/glib/unstable/glib-Strings.html#g-string-free
