### PR TITLE
Feature/remove compilation warnings

### DIFF
--- a/gst_client/gst_client.c
+++ b/gst_client/gst_client.c
@@ -287,7 +287,6 @@ main (gint argc, gchar * argv[])
   const gchar *history_env = "GSTC_HISTORY";
   gchar *history_full = NULL;
   GstdClientData *data;
-  quark = g_quark_from_static_string (GSTD_CLIENT_DOMAIN);
 
   /* Cmdline options */
   gboolean quiet;
@@ -342,6 +341,7 @@ main (gint argc, gchar * argv[])
     ,
     {NULL}
   };
+  quark = g_quark_from_static_string (GSTD_CLIENT_DOMAIN);
 
   /* Internationalization */
   setlocale (LC_ALL, "");
@@ -630,7 +630,6 @@ gstd_client_cmd_socket (gchar * name, gchar * arg, GstdClientData * data)
     gstd_client_process_error (err);
     goto write_error;
   }
-
   //Paranoia flush
   g_output_stream_flush (ostream, NULL, NULL);
 

--- a/gstd/gstd_element.c
+++ b/gstd/gstd_element.c
@@ -423,10 +423,10 @@ gstd_element_signals_to_string (GstdElement * self, GstdIFormatter * formatter)
 void
 gstd_element_internal_to_string (GstdElement * self, gchar ** outstring)
 {
-
+  GstdIFormatter *formatter = NULL;
   g_return_if_fail (GSTD_IS_OBJECT (self));
 
-  GstdIFormatter *formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
+  formatter = g_object_new (GSTD_TYPE_JSON_BUILDER, NULL);
   gstd_iformatter_begin_object (formatter);
 
   gstd_element_properties_to_string (self, formatter);

--- a/gstd/gstd_http.c
+++ b/gstd/gstd_http.c
@@ -290,10 +290,11 @@ do_request (gpointer data_request, gpointer eval)
   GstdSession *session = NULL;
   const char *path = NULL;
   GHashTable *query = NULL;
+  GstdHttpRequest *data_request_local = NULL;
 
   g_return_if_fail (data_request);
 
-  GstdHttpRequest *data_request_local = (GstdHttpRequest *) data_request;
+  data_request_local = (GstdHttpRequest *) data_request;
   g_mutex_lock (data_request_local->mutex);
   server = data_request_local->server;
   g_mutex_unlock (data_request_local->mutex);
@@ -353,15 +354,16 @@ server_callback (SoupServer * server, SoupMessage * msg,
     SoupClientContext * context, gpointer data)
 {
   GstdSession *session = NULL;
+  GstdHttp *self = NULL;
+  GstdHttpRequest *data_request = NULL;
 
   g_return_if_fail (server);
   g_return_if_fail (msg);
   g_return_if_fail (data);
 
-  GstdHttp *self = GSTD_HTTP (data);
+  self = GSTD_HTTP (data);
   session = self->session;
 
-  GstdHttpRequest *data_request;
   data_request = (GstdHttpRequest *) malloc (sizeof (GstdHttpRequest));
 
   data_request->msg = msg;
@@ -394,14 +396,17 @@ static GstdReturnCode
 gstd_http_start (GstdIpc * base, GstdSession * session)
 {
   GError *error = NULL;
-  GSocketAddress *sa;
+  GSocketAddress *sa = NULL;
+  GstdHttp *self = NULL;
+  guint16 port = 0;
+  gchar *address = NULL;
 
   g_return_val_if_fail (base, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (session, GSTD_NULL_ARGUMENT);
 
-  GstdHttp *self = GSTD_HTTP (base);
-  guint16 port = self->port;
-  gchar *address = self->address;
+  self = GSTD_HTTP (base);
+  port = self->port;
+  address = self->address;
 
   self->session = session;
   gstd_http_stop (base);
@@ -445,11 +450,7 @@ noconnection:
 static gboolean
 gstd_http_init_get_option_group (GstdIpc * base, GOptionGroup ** group)
 {
-  g_return_val_if_fail (base, FALSE);
-  g_return_val_if_fail (group, FALSE);
-
-  GstdHttp *self = GSTD_HTTP (base);
-
+  GstdHttp *self = NULL;
   GOptionEntry http_args[] = {
     {"enable-http-protocol", 't', 0, G_OPTION_ARG_NONE, &base->enabled,
         "Enable attach the server through given HTTP ports ", NULL}
@@ -469,6 +470,12 @@ gstd_http_init_get_option_group (GstdIpc * base, GOptionGroup ** group)
     ,
     {NULL}
   };
+
+  g_return_val_if_fail (base, FALSE);
+  g_return_val_if_fail (group, FALSE);
+
+  self = GSTD_HTTP (base);
+
   GST_DEBUG_OBJECT (self, "HTTP init group callback ");
   *group = g_option_group_new ("gstd-http", ("HTTP Options"),
       ("Show HTTP Options"), NULL, NULL);
@@ -480,10 +487,12 @@ gstd_http_init_get_option_group (GstdIpc * base, GOptionGroup ** group)
 static GstdReturnCode
 gstd_http_stop (GstdIpc * base)
 {
+  GstdHttp *self = NULL;
+  GstdSession *session = NULL;
   g_return_val_if_fail (base, GSTD_NULL_ARGUMENT);
 
-  GstdHttp *self = GSTD_HTTP (base);
-  GstdSession *session = base->session;
+  self = GSTD_HTTP (base);
+  session = base->session;
 
   GST_INFO_OBJECT (session, "Closing HTTP server connection for %s",
       GSTD_OBJECT_NAME (session));


### PR DESCRIPTION
Remove compilation warning:` warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]`