### PR TITLE
tests: set PLUGIN_PATH to meson root path when building inside gst-build

### DIFF
--- a/tests/gstd/meson.build
+++ b/tests/gstd/meson.build
@@ -11,8 +11,11 @@ test_defines = [
   '-DTESTFILE="' + meson.current_source_dir() + '/meson.build"',
 ]
 
+plugins_dir = []
 # Define plugins path
-plugins_dir = gst_dep.get_pkgconfig_variable('pluginsdir')
+if gst_dep.type_name() == 'pkgconfig'
+   plugins_dir =[gst_dep.get_pkgconfig_variable('pluginsdir')]
+endif
 
 # Create environment object to  stores information about the environment
 # variables set during tests.
@@ -20,7 +23,7 @@ plugins_dir = gst_dep.get_pkgconfig_variable('pluginsdir')
 env = environment()
 env.set('GST_PLUGIN_SYSTEM_PATH_1_0', '')
 env.set('CK_DEFAULT_TIMEOUT', '120')
-env.set('GST_PLUGIN_PATH_1_0', lib_gstd_dir + ':' + plugins_dir)
+env.set('GST_PLUGIN_PATH_1_0',  [meson.build_root()] + plugins_dir)
 
 # Build and run tests
 foreach t : gstd_tests

--- a/tests/libgstc/c/meson.build
+++ b/tests/libgstc/c/meson.build
@@ -29,8 +29,11 @@ lib_gstc_client = [
   ['test_libgstc_socket.c', lib_gstc_dir + '/libgstc_assert.c', lib_gstc_dir + '/libgstc_thread.c', lib_gstc_dir + '/libgstc_socket.c'],
 ]
 
+plugins_dir = []
 # Define plugins path
-plugins_dir = gst_dep.get_pkgconfig_variable('pluginsdir')
+if gst_dep.type_name() == 'pkgconfig'
+   plugins_dir = [gst_dep.get_pkgconfig_variable('pluginsdir')]
+endif
 
 # Create environment object to  stores information about the environment
 # variables set during tests.
@@ -38,7 +41,7 @@ plugins_dir = gst_dep.get_pkgconfig_variable('pluginsdir')
 env = environment()
 env.set('GST_PLUGIN_SYSTEM_PATH_1_0', '')
 env.set('CK_DEFAULT_TIMEOUT', '120')
-env.set('GST_PLUGIN_PATH_1_0', lib_gstd_dir + ':' + plugins_dir)
+env.set('GST_PLUGIN_PATH_1_0', [meson.build_root()] + plugins_dir)
 
 # Build and run tests
 foreach t : lib_gstc_tests


### PR DESCRIPTION
This adds to GST_PLUGIN_PATH_1_0 the meson build root directory and sets
plugins_dir variable only if the build is outside a gst-build
environment to avoid the following error:

ERROR: Method "get_pkgconfig_variable()" is invalid for an internal dependency