### PR TITLE
Feature/change gstd manager name

### DIFF
--- a/gstd/gstd.c
+++ b/gstd/gstd.c
@@ -77,7 +77,7 @@ main (gint argc, gchar * argv[])
   gchar *filename = NULL;
   gboolean parent = FALSE;
 
-  GstDManager *manager = NULL;
+  GstD *gstd = NULL;
 
   GOptionEntry entries[] = {
     {"version", 'v', 0, G_OPTION_ARG_NONE, &version,
@@ -109,8 +109,8 @@ main (gint argc, gchar * argv[])
   g_option_context_add_main_entries (context, entries, NULL);
 
   /* Initialize GStreamer */
-  gstd_new (&manager, 0, NULL);
-  gstd_context_add_group (manager, context);
+  gstd_new (&gstd, 0, NULL);
+  gstd_context_add_group (gstd, context);
 
   /* Parse the options before starting */
   if (!g_option_context_parse (context, &argc, &argv, &error)) {
@@ -167,7 +167,7 @@ main (gint argc, gchar * argv[])
   }
 
   /* Start IPC subsystem */
-  if (!gstd_start (manager)) {
+  if (!gstd_start (gstd)) {
     goto error;
   }
 
@@ -189,7 +189,7 @@ main (gint argc, gchar * argv[])
   main_loop = NULL;
 
   /* Stop any IPC array */
-  gstd_stop (manager);
+  gstd_stop (gstd);
 
   gstd_log_deinit ();
 
@@ -207,7 +207,7 @@ error:
 out:
   {
     gst_deinit ();
-    gstd_free (manager);
+    gstd_free (gstd);
     return ret;
   }
 }

--- a/gstd/gstd.c
+++ b/gstd/gstd.c
@@ -109,7 +109,7 @@ main (gint argc, gchar * argv[])
   g_option_context_add_main_entries (context, entries, NULL);
 
   /* Initialize GStreamer */
-  gstd_manager_new (&manager, 0, NULL);
+  gstd_new (&manager, 0, NULL);
   gstd_context_add_group (manager, context);
 
   /* Parse the options before starting */
@@ -167,7 +167,7 @@ main (gint argc, gchar * argv[])
   }
 
   /* Start IPC subsystem */
-  if (!gstd_manager_start (manager)) {
+  if (!gstd_start (manager)) {
     goto error;
   }
 
@@ -189,7 +189,7 @@ main (gint argc, gchar * argv[])
   main_loop = NULL;
 
   /* Stop any IPC array */
-  gstd_manager_stop (manager);
+  gstd_stop (manager);
 
   gstd_log_deinit ();
 
@@ -207,7 +207,7 @@ error:
 out:
   {
     gst_deinit ();
-    gstd_manager_free (manager);
+    gstd_free (manager);
     return ret;
   }
 }

--- a/libgstd/libgstd.c
+++ b/libgstd/libgstd.c
@@ -59,8 +59,8 @@ enum _SupportedIpcs
 };
 
 static GType gstd_supported_ipc_to_ipc (const SupportedIpcs code);
-static void gstd_manager_init (int argc, char *argv[]);
-static void gstd_manager_set_ipc (GstDManager * manager);
+static void gstd_init (int argc, char *argv[]);
+static void gstd_set_ipc (GstDManager * manager);
 
 struct _GstDManager
 {
@@ -87,14 +87,14 @@ gstd_supported_ipc_to_ipc (const SupportedIpcs code)
 }
 
 static void
-gstd_manager_init (int argc, char *argv[])
+gstd_init (int argc, char *argv[])
 {
   gst_init (&argc, &argv);
   gstd_debug_init ();
 }
 
 static void
-gstd_manager_set_ipc (GstDManager * manager)
+gstd_set_ipc (GstDManager * manager)
 {
   /* Array to specify gstd how many IPCs are supported, 
    * SupportedIpcs should be added to this array.
@@ -152,7 +152,7 @@ gstd_context_add_group (GstDManager * manager, GOptionContext * context)
 }
 
 GstdStatus
-gstd_manager_new (GstDManager ** out, int argc, char *argv[])
+gstd_new (GstDManager ** out, int argc, char *argv[])
 {
   GstdStatus ret = GSTD_LIB_OK;
   GstDManager *manager = NULL;
@@ -167,18 +167,18 @@ gstd_manager_new (GstDManager ** out, int argc, char *argv[])
   manager->num_ipcs = 0;
   manager->ipc_array = NULL;
 
-  gstd_manager_set_ipc (manager);
+  gstd_set_ipc (manager);
 
   *out = manager;
 
   /* Initialize GStreamer */
-  gstd_manager_init (argc, argv);
+  gstd_init (argc, argv);
 
   return ret;
 }
 
 gboolean
-gstd_manager_start (GstDManager * manager)
+gstd_start (GstDManager * manager)
 {
   gboolean ipc_selected = FALSE;
   gboolean ret = TRUE;
@@ -218,7 +218,7 @@ gstd_manager_start (GstDManager * manager)
 }
 
 void
-gstd_manager_stop (GstDManager * manager)
+gstd_stop (GstDManager * manager)
 {
   g_return_if_fail (NULL != manager);
   g_return_if_fail (NULL != manager->ipc_array);
@@ -235,10 +235,10 @@ gstd_manager_stop (GstDManager * manager)
 }
 
 void
-gstd_manager_free (GstDManager * manager)
+gstd_free (GstDManager * manager)
 {
   g_return_if_fail (NULL != manager);
-  gstd_manager_stop (manager);
+  gstd_stop (manager);
   g_free (manager->ipc_array);
   g_object_unref (manager->session);
   g_free (manager);

--- a/libgstd/libgstd.h
+++ b/libgstd/libgstd.h
@@ -72,7 +72,7 @@ void
 gstd_context_add_group (GstDManager *manager, GOptionContext *context);
 
 /**
- * gstd_manager_new:
+ * gstd_new:
  * 
  * @out: placeholder for newly allocated gstd manager.
  * @argc: arguments for gst_init
@@ -83,33 +83,33 @@ gstd_context_add_group (GstDManager *manager, GOptionContext *context);
  * Returns: GstdStatus indicating success or fail
  */
 GstdStatus 
-gstd_manager_new (GstDManager ** out, int argc, char *argv[]);
+gstd_new (GstDManager ** out, int argc, char *argv[]);
 
 
 /**
- * gstd_manager_start:
- * @manager: The manager returned by gstd_manager_new()
+ * gstd_start:
+ * @manager: The manager returned by gstd_new()
  * 
  * Starts the ipc in GstdIpc array
  *
  * Returns: GstdStatus indicating success or fail
  */
 int
-gstd_manager_start (GstDManager * manager);
+gstd_start (GstDManager * manager);
 
 /**
- * gstd_manager_stop:
- * @manager: The manager returned by gstd_manager_new()
+ * gstd_stop:
+ * @manager: The manager returned by gstd_new()
  * 
  * Stops the ipc in GstdIpc array
  *
  * Returns: GstdStatus indicating success or fail
  */
 void
-gstd_manager_stop (GstDManager * manager);
+gstd_stop (GstDManager * manager);
 
 /**
- * gstd_manager_free:
+ * gstd_free:
  * @manager: A valid manager allocated with gstd_new()
  *
  * Frees a previously allocated GstDManager.
@@ -118,7 +118,7 @@ gstd_manager_stop (GstDManager * manager);
  * usage.
  */
 void
-gstd_manager_free (GstDManager * manager);
+gstd_free (GstDManager * manager);
 
 
 #ifdef __cplusplus

--- a/libgstd/libgstd.h
+++ b/libgstd/libgstd.h
@@ -29,11 +29,11 @@ extern "C"
 #include <glib-unix.h>
 
 /*
- * GstDManager:
+ * GstD:
  * Opaque representation of GstD state.
  * This struct will have: Session, GstdIpc and num_ipcs (for now)
  */
-typedef struct _GstDManager GstDManager;
+typedef struct _GstD GstD;
 
 /**
  * GstdStatus:
@@ -65,16 +65,17 @@ typedef enum
 /**
  * gstd_context_add_group:
  * 
- * Returns: A GOptionGroup with GStreamer's argument specification.
+ * @gstd: The gstd returned by gstd_new()
+ * @out: GOptionContext which will contain the GstDOptions
  * 
  */
 void
-gstd_context_add_group (GstDManager *manager, GOptionContext *context);
+gstd_context_add_group (GstD *gstd, GOptionContext *context);
 
 /**
  * gstd_new:
  * 
- * @out: placeholder for newly allocated gstd manager.
+ * @out: placeholder for newly allocated gstd instance.
  * @argc: arguments for gst_init
  * @argv: arguments for gst_init
  * 
@@ -83,42 +84,42 @@ gstd_context_add_group (GstDManager *manager, GOptionContext *context);
  * Returns: GstdStatus indicating success or fail
  */
 GstdStatus 
-gstd_new (GstDManager ** out, int argc, char *argv[]);
+gstd_new (GstD ** out, int argc, char *argv[]);
 
 
 /**
  * gstd_start:
- * @manager: The manager returned by gstd_new()
+ * @gstd: The gstd returned by gstd_new()
  * 
  * Starts the ipc in GstdIpc array
  *
  * Returns: GstdStatus indicating success or fail
  */
 int
-gstd_start (GstDManager * manager);
+gstd_start (GstD * gstd);
 
 /**
  * gstd_stop:
- * @manager: The manager returned by gstd_new()
+ * @gstd: The gstd instance returned by gstd_new()
  * 
  * Stops the ipc in GstdIpc array
  *
  * Returns: GstdStatus indicating success or fail
  */
 void
-gstd_stop (GstDManager * manager);
+gstd_stop (GstD * gstd);
 
 /**
  * gstd_free:
- * @manager: A valid manager allocated with gstd_new()
+ * @gstd: A valid gstd instance allocated with gstd_new()
  *
- * Frees a previously allocated GstDManager.
+ * Frees a previously allocated GstD.
  *
- * Returns: A newly allocated GstDManager. Use gstd_free() after
+ * Returns: A newly allocated GstD. Use gstd_free() after
  * usage.
  */
 void
-gstd_free (GstDManager * manager);
+gstd_free (GstD * gstd);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Libgstd does not use the word "manager" anymore in its functions 