### PR TITLE
meson.build: use dependency function for readline

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,8 +30,8 @@ systemd_required = get_option('enable-systemd').enabled()
 systemd_dep = dependency('systemd', required : systemd_required, version : '>=232')
 
 cc = meson.get_compiler('c')
-readline = cc.find_library('readline', required: true)
-if readline.found()
+readline_dep = dependency('readline')
+if readline_dep.found()
   add_project_arguments('-DHAVE_LIBREADLINE', language: 'c')
   add_project_arguments('-DHAVE_READLINE_HISTORY', language: 'c')
   # Add arguments to the compiler command line. 
@@ -46,8 +46,6 @@ if readline.found()
   else
     add_project_arguments('-DHAVE_HISTORY_H', language: 'c')
   endif
-  
-  readline_dep = readline
 endif
 
 ## Dependencies


### PR DESCRIPTION
Use meson `dependency` function to find readline instead of `cc.find_library`.
This function will retrieve readline pkg-config file which is available since version 7 (released 5 years ago) and https://git.savannah.gnu.org/cgit/readline.git/commit/readline.pc.in?id=d49a9082c0e15bba8cd3d8cc0a994409cf823cac. 
`readline.pc` sets `tinfo` in `Requires.private` which will avoid the following static build failure:

```
/home/buildroot/autobuild/instance-1/output-1/host/opt/ext-toolchain/bin/../lib/gcc/i586-buildroot-linux-musl/9.3.0/../../../../i586-buildroot-linux-musl/bin/ld: /home/buildroot/autobuild/instance-1/output-1/host/i586-buildroot-linux-musl/sysroot/usr/lib/libreadline.a(display.o): in function `_rl_move_cursor_relative':
display.c:(.text+0xbb5): undefined reference to `tputs'
```

Fixes:
 - http://autobuild.buildroot.org/results/77c10947ddc749c54c7c233e3143f5cdf1edc73d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>