### PR TITLE
Hotfix/fix deadlock on receive

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl required version of autoconf
 AC_PREREQ([2.53])
 
 dnl Gstreamer's daemon package name and version
-AC_INIT([gstd],[0.13.0])
+AC_INIT([gstd],[0.13.1])
 
 dnl required version of gstreamer and gst-plugins-base
 GST_REQUIRED=1.0.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gstd (0.13.1-1) unstable; urgency=medium
+
+  * Fix deadlock when a socket dies or closes incorrectly on PyGstc
+
+ -- RidgeRun Engineering <support@ridgerun.com>  Wed, 08 Dec 08:30:00  -0600
+
 gstd (0.13.0-1) unstable; urgency=medium
 
   * Add libgstc support to get pipeline state

--- a/libgstc/python/pygstc/tcp.py
+++ b/libgstc/python/pygstc/tcp.py
@@ -176,6 +176,11 @@ class Ipc:
             except socket.error as e:
                 raise TimeoutError from e
 
+            # When a connection dies, the socket does not close properly and it
+            # returns immediately with an empty string. So, check that first.
+            if len(newbuf) == 0:
+                break
+
             if self._terminator in newbuf:
                 buf += newbuf[:newbuf.find(self._terminator)]
                 break

--- a/libgstc/python/setup.py
+++ b/libgstc/python/setup.py
@@ -33,7 +33,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pygstc',
-    version='0.2.0',
+    version='0.2.1',
     description='Python GStreamer Daemon Client',
     long_description='Python GStreamer Daemon Client',
     long_description_content_type='text/markdown',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('gstd', 'c',
-  version : '0.13.0',
+  version : '0.13.1',
   meson_version : '>= 0.50',)
 
 gstd_version = meson.project_version()


### PR DESCRIPTION
This hotfix addresses:

* Deadlock caused by a socket death

A socket death can be caused by a segfault internally generated in `gstd` + `gstreamer`.

Way to reproduce the issue:

* Use PyGSTC bindings
* Send any request within a loop. In our case, we tried `signal_connect`
* Send a SEGFAULT to the gstd `kill -11 $GSTD_PID`
* Look at the CPU usage

Mitigation:

* Check that the buffer is not empty when receiving a buffer: timeouts are caught as exceptions. Most instructions do not return an empty response.