### PR TITLE
Feature/fix gstd actions meson install

### DIFF
--- a/libgstd/gstd_action.h
+++ b/libgstd/gstd_action.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
 
 typedef struct _GstdAction GstdAction;
 typedef struct _GstdActionClass GstdActionClass;
-GType gstd_action_get_type ();
+GType gstd_action_get_type (void);
 
 struct _GstdAction
 {

--- a/libgstd/gstd_element.c
+++ b/libgstd/gstd_element.c
@@ -402,7 +402,7 @@ gstd_element_properties_to_string (GstdElement * self,
 
 }
 
-void
+static void
 gstd_element_signals_to_string_internal (GstdElement * self,
     GList * signal_list, GstdIFormatter * formatter)
 {

--- a/libgstd/meson.build
+++ b/libgstd/meson.build
@@ -5,6 +5,7 @@ gstd_headers = [
 
 # Common files needed for GstD and libGstD
 gstd_src = [
+  'gstd_action.c',
   'gstd_object.c',
   'gstd_pipeline.c',
   'gstd_element.c',


### PR DESCRIPTION
This feature fixes:

https://github.com/RidgeRun/gstd-1.x/issues/276

* Adds the file to the meson: fixing the construction issue
* Removes warnings from actions not detected by Autotools installation