### PR TITLE
Fix python tests and use individual gstd runners for each test

### DIFF
--- a/tests/libgstc/Makefile.am
+++ b/tests/libgstc/Makefile.am
@@ -1,5 +1,3 @@
 SUBDIRS=c
 
-# FIXME Disable pygstc checks
-#SUBDIRS = python
-
+SUBDIRS=python

--- a/tests/libgstc/python/Makefile.am
+++ b/tests/libgstc/python/Makefile.am
@@ -29,4 +29,6 @@ TESTS = \
 	test_libgstc_python_update.py \
 	test_libgstc_python_stop_gstd.py
 
-export PYTHONPATH = $PYTHONPATH:$(top_srcdir)/libgstc
+check_SCRIPTS = $(TESTS)
+
+export PYTHONPATH = $PYTHONPATH:$(top_srcdir)/libgstc/python

--- a/tests/libgstc/python/test_libgstc_python_bus_filter.py
+++ b/tests/libgstc/python/test_libgstc_python_bus_filter.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcBusFilterMethods(unittest.TestCase):
+class TestGstcBusFilterMethods(GstdTestRunner):
 
     def test_bus_filter_eos(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         self.gstd_client.event_eos('p0')

--- a/tests/libgstc/python/test_libgstc_python_bus_timeout.py
+++ b/tests/libgstc/python/test_libgstc_python_bus_timeout.py
@@ -31,30 +31,32 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcBusTimeoutMethods(unittest.TestCase):
+class TestGstcBusTimeoutMethods(GstdTestRunner):
 
     def test_bus_timeout_eos(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         self.gstd_client.event_eos('p0')
         self.gstd_client.bus_filter('p0', 'eos')
         self.gstd_client.bus_timeout('p0', 1000)
         ret = self.gstd_client.bus_read('p0')
-        self.assertEqual(ret['type'], 'eos')
+        if ret:
+            self.assertEqual(ret['type'], 'eos')
         self.gstd_client.pipeline_stop('p0')
         self.gstd_client.pipeline_delete('p0')
 
     def test_bus_timeout_no_response(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         self.gstd_client.bus_timeout('p0', 1000)

--- a/tests/libgstc/python/test_libgstc_python_create.py
+++ b/tests/libgstc/python/test_libgstc_python_create.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcCreateMethods(unittest.TestCase):
+class TestGstcCreateMethods(GstdTestRunner):
 
     def test_create_pipeline(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         ret = self.gstd_client.read('pipelines')
         initial_n_pipes = len(ret['nodes'])
         self.gstd_client.create('pipelines', 'p0', pipeline)
@@ -52,7 +53,7 @@ class TestGstcCreateMethods(unittest.TestCase):
     def test_create_bad_pipeline(self):
         pipeline = 'source sink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         with self.assertRaises(GstdError):
             self.gstd_client.create('pipelines', 'p0', pipeline)
 

--- a/tests/libgstc/python/test_libgstc_python_debug_color.py
+++ b/tests/libgstc/python/test_libgstc_python_debug_color.py
@@ -31,20 +31,21 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcDebugColorMethods(unittest.TestCase):
+class TestGstcDebugColorMethods(GstdTestRunner):
 
     def test_debug_color_true(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_color(True)
 
     def test_debug_color_false(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_color(False)
 
 

--- a/tests/libgstc/python/test_libgstc_python_debug_enable.py
+++ b/tests/libgstc/python/test_libgstc_python_debug_enable.py
@@ -31,20 +31,21 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcDebugEnableMethods(unittest.TestCase):
+class TestGstcDebugEnableMethods(GstdTestRunner):
 
     def test_debug_enable_true(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_enable(True)
 
     def test_debug_enable_false(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_enable(False)
 
 

--- a/tests/libgstc/python/test_libgstc_python_debug_reset.py
+++ b/tests/libgstc/python/test_libgstc_python_debug_reset.py
@@ -31,20 +31,21 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcDebugResetMethods(unittest.TestCase):
+class TestGstcDebugResetMethods(GstdTestRunner):
 
     def test_debug_reset_true(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_reset(True)
 
     def test_debug_reset_false(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_reset(False)
 
 

--- a/tests/libgstc/python/test_libgstc_python_debug_threshold.py
+++ b/tests/libgstc/python/test_libgstc_python_debug_threshold.py
@@ -30,60 +30,61 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcDebugThresholdMethods(unittest.TestCase):
+class TestGstcDebugThresholdMethods(GstdTestRunner):
 
     def test_debug_threshold_none(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('0')
 
     def test_debug_threshold_error(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('1')
 
     def test_debug_threshold_warning(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('2')
 
     def test_debug_threshold_fixme(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('3')
 
     def test_debug_threshold_info(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('4')
 
     def test_debug_threshold_debug(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('5')
 
     def test_debug_threshold_log(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('6')
 
     def test_debug_threshold_trace(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('7')
 
     def test_debug_threshold_memdump(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('8')
 
     def test_debug_threshold_invalid(self):
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.debug_threshold('9')
 
 

--- a/tests/libgstc/python/test_libgstc_python_delete.py
+++ b/tests/libgstc/python/test_libgstc_python_delete.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcDeleteMethods(unittest.TestCase):
+class TestGstcDeleteMethods(GstdTestRunner):
 
     def test_delete_pipeline(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         ret = self.gstd_client.read('pipelines')
         initial_n_pipes = len(ret['nodes'])
         self.gstd_client.create('pipelines', 'p0', pipeline)

--- a/tests/libgstc/python/test_libgstc_python_element_get.py
+++ b/tests/libgstc/python/test_libgstc_python_element_get.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcElementGetMethods(unittest.TestCase):
+class TestGstcElementGetMethods(GstdTestRunner):
 
     def test_element_get_property_value(self):
         pipeline = 'videotestsrc name=v0 pattern=ball ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.assertEqual(
             self.gstd_client.element_get(

--- a/tests/libgstc/python/test_libgstc_python_element_set.py
+++ b/tests/libgstc/python/test_libgstc_python_element_set.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcElementSetMethods(unittest.TestCase):
+class TestGstcElementSetMethods(GstdTestRunner):
 
     def test_element_set_property_value(self):
         pipeline = 'videotestsrc name=v0 pattern=ball ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.assertEqual(
             self.gstd_client.element_get(

--- a/tests/libgstc/python/test_libgstc_python_event_eos.py
+++ b/tests/libgstc/python/test_libgstc_python_event_eos.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcEventEosMethods(unittest.TestCase):
+class TestGstcEventEosMethods(GstdTestRunner):
 
     def test_event_eos(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         self.gstd_client.event_eos('p0')

--- a/tests/libgstc/python/test_libgstc_python_event_flush_start.py
+++ b/tests/libgstc/python/test_libgstc_python_event_flush_start.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcEventFlushStartMethods(unittest.TestCase):
+class TestGstcEventFlushStartMethods(GstdTestRunner):
 
     def test_event_flush_start(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         self.gstd_client.event_flush_start('p0')

--- a/tests/libgstc/python/test_libgstc_python_event_seek.py
+++ b/tests/libgstc/python/test_libgstc_python_event_seek.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcEventSeekMethods(unittest.TestCase):
+class TestGstcEventSeekMethods(GstdTestRunner):
 
     def test_event_seek(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         self.gstd_client.event_seek('p0')

--- a/tests/libgstc/python/test_libgstc_python_init.py
+++ b/tests/libgstc/python/test_libgstc_python_init.py
@@ -30,24 +30,21 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-import subprocess
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcInitMethods(unittest.TestCase):
-
-    def setUp(self):
-        subprocess.Popen(['gstd', '-p', '5000', '-n', '2'])
+class TestGstcInitMethods(GstdTestRunner):
 
     def test_init(self):
-        self.gstd_client = GstdClient()
+        self.gstd_client = GstdClient(port=self.port)
 
     def test_init_dummylogger(self):
         self.gstd_logger = DummyLogger()
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
 
     def test_init_logfile(self):
         f = open('dummy.log', 'w+')
@@ -57,7 +54,7 @@ class TestGstcInitMethods(unittest.TestCase):
         f.close()
         self.gstd_logger = CustomLogger('test_libgstc',
                                         logfile='dummy.log', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         f = open('dummy.log')
         num_lines_final = sum(1 for line in f)
         f.close()

--- a/tests/libgstc/python/test_libgstc_python_list_elements.py
+++ b/tests/libgstc/python/test_libgstc_python_list_elements.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcListElementsMethods(unittest.TestCase):
+class TestGstcListElementsMethods(GstdTestRunner):
 
     def test_list_elements(self):
         pipeline = 'videotestsrc name=v0 ! fakesink name=x0'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.assertEqual(self.gstd_client.list_elements('p0'),
                          [{'name': 'x0'}, {'name': 'v0'}])

--- a/tests/libgstc/python/test_libgstc_python_list_pipelines.py
+++ b/tests/libgstc/python/test_libgstc_python_list_pipelines.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcListPipelinesMethods(unittest.TestCase):
+class TestGstcListPipelinesMethods(GstdTestRunner):
 
     def test_list_pipelines(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         initial_n_pipes = len(self.gstd_client.list_pipelines())
         self.gstd_client.create('pipelines', 'p0', pipeline)
         final_n_pipes = len(self.gstd_client.list_pipelines())

--- a/tests/libgstc/python/test_libgstc_python_list_properties.py
+++ b/tests/libgstc/python/test_libgstc_python_list_properties.py
@@ -31,17 +31,18 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcListPropertiesMethods(unittest.TestCase):
+class TestGstcListPropertiesMethods(GstdTestRunner):
 
     def test_list_properties(self):
         pipeline = \
             'videotestsrc name=v0 ! identity name=i0 ! fakesink name=x0'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         identity_properties = [
             {'name': 'name'},
             {'name': 'parent'},

--- a/tests/libgstc/python/test_libgstc_python_list_signals.py
+++ b/tests/libgstc/python/test_libgstc_python_list_signals.py
@@ -31,20 +31,21 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcListSignalsMethods(unittest.TestCase):
+class TestGstcListSignalsMethods(GstdTestRunner):
 
     def test_list_signals(self):
         pipeline = \
             'videotestsrc name=v0 ! identity name=i0 ! fakesink name=x0'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
-        self.assertEqual(self.gstd_client.list_signals('p0', 'i0'),
-                         [{'name': 'handoff'}])
+        self.assertTrue({'name': 'handoff'} in
+                        self.gstd_client.list_signals('p0', 'i0'))
         self.gstd_client.pipeline_delete('p0')
 
 

--- a/tests/libgstc/python/test_libgstc_python_pipeline_create.py
+++ b/tests/libgstc/python/test_libgstc_python_pipeline_create.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcPipelineCreateMethods(unittest.TestCase):
+class TestGstcPipelineCreateMethods(GstdTestRunner):
 
     def test_libgstc_python_pipeline_create(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         ret = self.gstd_client.read('pipelines')
         self.assertEqual(ret['nodes'][0]['name'], 'p0')

--- a/tests/libgstc/python/test_libgstc_python_pipeline_delete.py
+++ b/tests/libgstc/python/test_libgstc_python_pipeline_delete.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcPipelineDeleteMethods(unittest.TestCase):
+class TestGstcPipelineDeleteMethods(GstdTestRunner):
 
     def test_libgstc_python_pipeline_delete(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         ret_prev = self.gstd_client.read('pipelines')
         len_prev = len(ret_prev['nodes'])

--- a/tests/libgstc/python/test_libgstc_python_pipeline_pause.py
+++ b/tests/libgstc/python/test_libgstc_python_pipeline_pause.py
@@ -29,21 +29,32 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import time
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
+DEFAULT_STATE_READ_RETRIES = 3
+DEFAULT_TIME_BETWEEN_RETRIES = 0.1 #seconds
+RUN_STATES = ['RUNNING', 'READY']
 
-class TestGstcPipelinePauseMethods(unittest.TestCase):
+class TestGstcPipelinePauseMethods(GstdTestRunner):
 
     def test_libgstc_python_pipeline_pause(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         self.gstd_client.pipeline_pause('p0')
+        state = self.gstd_client.read('pipelines/p0/state')['value']
+        retry = DEFAULT_STATE_READ_RETRIES
+        while (retry and state in RUN_STATES):
+            time.sleep(DEFAULT_TIME_BETWEEN_RETRIES)
+            state = self.gstd_client.read('pipelines/p0/state')['value']
+            retry -= 1
         self.assertEqual(self.gstd_client.read(
             'pipelines/p0/state')['value'], 'PAUSED')
         self.gstd_client.pipeline_delete('p0')

--- a/tests/libgstc/python/test_libgstc_python_pipeline_play.py
+++ b/tests/libgstc/python/test_libgstc_python_pipeline_play.py
@@ -32,16 +32,17 @@
 import time
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcPipelinePlayMethods(unittest.TestCase):
+class TestGstcPipelinePlayMethods(GstdTestRunner):
 
     def test_libgstc_python_pipeline_play(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         time.sleep(0.1)

--- a/tests/libgstc/python/test_libgstc_python_pipeline_stop.py
+++ b/tests/libgstc/python/test_libgstc_python_pipeline_stop.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcPipelineStopMethods(unittest.TestCase):
+class TestGstcPipelineStopMethods(GstdTestRunner):
 
     def test_libgstc_python_pipeline_stop(self):
         pipeline = 'videotestsrc name=v0 ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         self.gstd_client.pipeline_stop('p0')

--- a/tests/libgstc/python/test_libgstc_python_signal_connect.py
+++ b/tests/libgstc/python/test_libgstc_python_signal_connect.py
@@ -31,17 +31,18 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcSignalConnectMethods(unittest.TestCase):
+class TestGstcSignalConnectMethods(GstdTestRunner):
 
     def test_libgstc_python_signal_connect(self):
         pipeline = \
             'videotestsrc ! identity signal-handoffs=true name=identity ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.pipeline_play('p0')
         ret = self.gstd_client.signal_connect('p0', 'identity',

--- a/tests/libgstc/python/test_libgstc_python_signal_disconnect.py
+++ b/tests/libgstc/python/test_libgstc_python_signal_disconnect.py
@@ -32,6 +32,7 @@
 import unittest
 import threading
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 import time
@@ -40,22 +41,22 @@ import os
 ret_val = ''
 
 
-def signal_connect_test():
+def signal_connect_test(port):
     global ret_val
     gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-    gstd_client = GstdClient(logger=gstd_logger)
+    gstd_client = GstdClient(port=port, logger=gstd_logger)
     ret_val = gstd_client.signal_connect('p0', 'identity', 'handoff')
 
 
-class TestGstcSignalDisconnectMethods(unittest.TestCase):
+class TestGstcSignalDisconnectMethods(GstdTestRunner):
 
     def test_libgstc_python_signal_disconnect(self):
         global ret_val
         pipeline = 'videotestsrc ! identity name=identity ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
-        ret_thr = threading.Thread(target=signal_connect_test)
+        ret_thr = threading.Thread(target=signal_connect_test, args=(self.port,))
         ret_thr.start()
         time.sleep(0.1)
         self.gstd_client.signal_disconnect('p0', 'identity', 'handoff')

--- a/tests/libgstc/python/test_libgstc_python_signal_timeout.py
+++ b/tests/libgstc/python/test_libgstc_python_signal_timeout.py
@@ -32,16 +32,17 @@
 import unittest
 import threading
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcSignalTimeoutMethods(unittest.TestCase):
+class TestGstcSignalTimeoutMethods(GstdTestRunner):
 
     def test_libgstc_python_signal_timeout(self):
         pipeline = 'videotestsrc ! identity name=identity ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.signal_timeout('p0', 'identity', 'handoff', 1)
         ret_con = self.gstd_client.signal_connect('p0', 'identity',

--- a/tests/libgstc/python/test_libgstc_python_stop_gstd.py
+++ b/tests/libgstc/python/test_libgstc_python_stop_gstd.py
@@ -32,11 +32,13 @@
 import unittest
 import subprocess
 
+from gstd_runner import GstdTestRunner
 
-class TestGstcStopGstdMethods(unittest.TestCase):
+
+class TestGstcStopGstdMethods(GstdTestRunner):
 
     def test_libgstc_python_stop_gstd(self):
-        subprocess.Popen(['gstd', '-k'])
+        subprocess.Popen([self.gstd_path, '-k'])
 
 
 if __name__ == '__main__':

--- a/tests/libgstc/python/test_libgstc_python_update.py
+++ b/tests/libgstc/python/test_libgstc_python_update.py
@@ -31,16 +31,17 @@
 
 import unittest
 
+from gstd_runner import GstdTestRunner
 from pygstc.gstc import *
 from pygstc.logger import *
 
 
-class TestGstcUpdateMethods(unittest.TestCase):
+class TestGstcUpdateMethods(GstdTestRunner):
 
     def test_libgstc_python_update(self):
         pipeline = 'videotestsrc name=v0 pattern=snow ! fakesink'
         self.gstd_logger = CustomLogger('test_libgstc', loglevel='DEBUG')
-        self.gstd_client = GstdClient(logger=self.gstd_logger)
+        self.gstd_client = GstdClient(port=self.port, logger=self.gstd_logger)
         self.gstd_client.pipeline_create('p0', pipeline)
         self.gstd_client.update(
             'pipelines/p0/elements/v0/properties/pattern', 'ball')


### PR DESCRIPTION
This gets the tests running although gstd appears to have some bugs:
```python
FAIL: test_libgstc_python_pipeline_pause.py
===========================================


GstD version 0.14.0
Copyright (C) 2015-2021 RidgeRun (https://www.ridgerun.com)

2022-03-04 05:21:09,704  INFO    	Starting GstClient with ip=localhost port=45683
2022-03-04 05:21:09,704  INFO    	Sending ping to Gstd
2022-03-04 05:21:09,704  DEBUG    	GSTD socket sending line: ['list_pipelines']
2022-03-04 05:21:09,705  INFO    	Creating pipeline p0 with description "videotestsrc name=v0 ! fakesink"
2022-03-04 05:21:09,705  DEBUG    	GSTD socket sending line: ['pipeline_create', 'p0', 'videotestsrc name=v0 ! fakesink']
2022-03-04 05:21:09,710  INFO    	Playing pipeline p0
2022-03-04 05:21:09,710  DEBUG    	GSTD socket sending line: ['pipeline_play', 'p0']
2022-03-04 05:21:09,710  INFO    	Pausing pipeline p0
2022-03-04 05:21:09,711  DEBUG    	GSTD socket sending line: ['pipeline_pause', 'p0']
2022-03-04 05:21:09,711  INFO    	Reading uri pipelines/p0/state
2022-03-04 05:21:09,711  DEBUG    	GSTD socket sending line: ['read', 'pipelines/p0/state']

F
======================================================================
FAIL: test_libgstc_python_pipeline_pause (__main__.TestGstcPipelinePauseMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./test_libgstc_python_pipeline_pause.py", line 48, in test_libgstc_python_pipeline_pause
    self.assertEqual(self.gstd_client.read(
AssertionError: 'READY' != 'PAUSED'
- READY
+ PAUSED


----------------------------------------------------------------------
Ran 1 test in 1.135s

FAILED (failures=1)
FAIL test_libgstc_python_pipeline_pause.py (exit status: 1)
```
This failure only seems to happen some of the time:
```python
FAIL: test_libgstc_python_bus_timeout.py
========================================


GstD version 0.14.0
Copyright (C) 2015-2021 RidgeRun (https://www.ridgerun.com)

2022-03-04 05:21:09,693  INFO    	Starting GstClient with ip=localhost port=39289
2022-03-04 05:21:09,693  INFO    	Sending ping to Gstd
2022-03-04 05:21:09,693  DEBUG    	GSTD socket sending line: ['list_pipelines']
2022-03-04 05:21:09,694  INFO    	Creating pipeline p0 with description "videotestsrc name=v0 ! fakesink"
2022-03-04 05:21:09,694  DEBUG    	GSTD socket sending line: ['pipeline_create', 'p0', 'videotestsrc name=v0 ! fakesink']
2022-03-04 05:21:09,697  INFO    	Playing pipeline p0
2022-03-04 05:21:09,698  DEBUG    	GSTD socket sending line: ['pipeline_play', 'p0']
2022-03-04 05:21:09,698  INFO    	Sending end-of-stream event to pipeline p0
2022-03-04 05:21:09,698  DEBUG    	GSTD socket sending line: ['event_eos', 'p0']
0:00:00.035864828 511270 0x560cb3265000 ERROR           gstdnoreader gstd_no_reader.c:77:gstd_no_reader_read:<GstdNoReader@0x7f5980131c80> Unable to read from this resource
2022-03-04 05:21:09,701  INFO    	Setting bus read filter of pipeline p0 to eos
2022-03-04 05:21:09,701  DEBUG    	GSTD socket sending line: ['bus_filter', 'p0', 'eos']
2022-03-04 05:21:09,702  INFO    	Setting bus read timeout of pipeline p0 to 1000
2022-03-04 05:21:09,702  DEBUG    	GSTD socket sending line: ['bus_timeout', 'p0', '1000']
2022-03-04 05:21:09,702  INFO    	Reading bus of pipeline p0
2022-03-04 05:21:09,703  DEBUG    	GSTD socket sending line: ['bus_read', 'p0']

E
GstD version 0.14.0
Copyright (C) 2015-2021 RidgeRun (https://www.ridgerun.com)

2022-03-04 05:21:10,738  INFO    	Starting GstClient with ip=localhost port=37507
2022-03-04 05:21:10,738  INFO    	Starting GstClient with ip=localhost port=37507
2022-03-04 05:21:10,738  INFO    	Sending ping to Gstd
2022-03-04 05:21:10,738  INFO    	Sending ping to Gstd
2022-03-04 05:21:10,738  DEBUG    	GSTD socket sending line: ['list_pipelines']
2022-03-04 05:21:10,738  DEBUG    	GSTD socket sending line: ['list_pipelines']
2022-03-04 05:21:10,739  INFO    	Creating pipeline p0 with description "videotestsrc name=v0 ! fakesink"
2022-03-04 05:21:10,739  INFO    	Creating pipeline p0 with description "videotestsrc name=v0 ! fakesink"
2022-03-04 05:21:10,739  DEBUG    	GSTD socket sending line: ['pipeline_create', 'p0', 'videotestsrc name=v0 ! fakesink']
2022-03-04 05:21:10,739  DEBUG    	GSTD socket sending line: ['pipeline_create', 'p0', 'videotestsrc name=v0 ! fakesink']
2022-03-04 05:21:10,742  INFO    	Playing pipeline p0
2022-03-04 05:21:10,742  INFO    	Playing pipeline p0
2022-03-04 05:21:10,742  DEBUG    	GSTD socket sending line: ['pipeline_play', 'p0']
2022-03-04 05:21:10,742  DEBUG    	GSTD socket sending line: ['pipeline_play', 'p0']
2022-03-04 05:21:10,742  INFO    	Setting bus read timeout of pipeline p0 to 1000
2022-03-04 05:21:10,742  INFO    	Setting bus read timeout of pipeline p0 to 1000
2022-03-04 05:21:10,743  DEBUG    	GSTD socket sending line: ['bus_timeout', 'p0', '1000']
2022-03-04 05:21:10,743  DEBUG    	GSTD socket sending line: ['bus_timeout', 'p0', '1000']
2022-03-04 05:21:10,743  INFO    	Reading bus of pipeline p0
2022-03-04 05:21:10,743  INFO    	Reading bus of pipeline p0
2022-03-04 05:21:10,743  DEBUG    	GSTD socket sending line: ['bus_read', 'p0']
2022-03-04 05:21:10,743  DEBUG    	GSTD socket sending line: ['bus_read', 'p0']
2022-03-04 05:21:10,743  INFO    	Stoping pipeline p0
2022-03-04 05:21:10,743  INFO    	Stoping pipeline p0
2022-03-04 05:21:10,743  DEBUG    	GSTD socket sending line: ['pipeline_stop', 'p0']
2022-03-04 05:21:10,743  DEBUG    	GSTD socket sending line: ['pipeline_stop', 'p0']
2022-03-04 05:21:10,745  INFO    	Deleting pipeline p0
2022-03-04 05:21:10,745  INFO    	Deleting pipeline p0
2022-03-04 05:21:10,745  DEBUG    	GSTD socket sending line: ['pipeline_delete', 'p0']
2022-03-04 05:21:10,745  DEBUG    	GSTD socket sending line: ['pipeline_delete', 'p0']

.
======================================================================
ERROR: test_bus_timeout_eos (__main__.TestGstcBusTimeoutMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./test_libgstc_python_bus_timeout.py", line 51, in test_bus_timeout_eos
    self.assertEqual(ret['type'], 'eos')
TypeError: 'NoneType' object is not subscriptable

----------------------------------------------------------------------
Ran 2 tests in 1.184s

FAILED (errors=1)
FAIL test_libgstc_python_bus_timeout.py (exit status: 1)
```