### PR TITLE
Do not check object creation after sending EOS

### DIFF
--- a/libgstd/gstd_no_reader.c
+++ b/libgstd/gstd_no_reader.c
@@ -74,8 +74,6 @@ static GstdReturnCode
 gstd_no_reader_read (GstdIReader * iface, GstdObject * object,
     const gchar * name, GstdObject ** out)
 {
-  GST_ERROR_OBJECT (iface, "Unable to read from this resource");
-
   *out = NULL;
 
   return GSTD_NO_READ;

--- a/libgstd/gstd_parser.c
+++ b/libgstd/gstd_parser.c
@@ -270,13 +270,10 @@ gstd_parser_create (GstdSession * session, GstdObject * obj, gchar * args,
   if (ret)
     goto out;
 
-  if (0 != strcmp (name, "eos")) {
-    gstd_object_read (obj, name, &new);
-
-    if (NULL != new) {
-      gstd_object_to_string (new, response);
-      g_object_unref (new);
-    }
+  gstd_object_read (obj, name, &new);
+  if (NULL != new) {
+    gstd_object_to_string (new, response);
+    g_object_unref (new);
   }
 
 out:

--- a/libgstd/gstd_parser.c
+++ b/libgstd/gstd_parser.c
@@ -270,11 +270,13 @@ gstd_parser_create (GstdSession * session, GstdObject * obj, gchar * args,
   if (ret)
     goto out;
 
-  gstd_object_read (obj, name, &new);
+  if (0 != strcmp (name, "eos")) {
+    gstd_object_read (obj, name, &new);
 
-  if (NULL != new) {
-    gstd_object_to_string (new, response);
-    g_object_unref (new);
+    if (NULL != new) {
+      gstd_object_to_string (new, response);
+      g_object_unref (new);
+    }
   }
 
 out:


### PR DESCRIPTION
The original logic checks if the object was created in GstD after sending EOS and it always generates an error because EOS doesn't produce a new object:

```
pipeline_create p0 videotestsrc ! fakesink
pipeline_play p0
event_eos p0
```

```
0:00:43.282238621 13498   0x7f98003630 ERROR           gstdnoreader gstd_no_reader.c:77:gstd_no_reader_read:<GstdNoReader@0x7fa002a480> Unable to read from this resource
```

@jameshilliard reported that it can be reproduced with unit tests:

> I think I managed to reproduce this Unable to read from this resource error by enabling the python tests in https://github.com/RidgeRun/gstd-1.x/pull/278.
