### PR TITLE
meson: set check kwarg for run_command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -269,8 +269,8 @@ pkgconfig = import('pkgconfig')
 
 # Install git hooks
 run_command('rm', '-f', '.git/hooks/pre-commit',
-'.git/hooks/pre-commit')
-r = run_command('ln', '-s', '../../common/hooks/pre-commit.hook', '.git/hooks/pre-commit')
+'.git/hooks/pre-commit', check: false)
+r = run_command('ln', '-s', '../../common/hooks/pre-commit.hook', '.git/hooks/pre-commit', check: false)
 if r.returncode() != 0
   warning('Failed to create commit hook')
 endif


### PR DESCRIPTION
Current logic expects this to be set to false.

Fixes:
```
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
```