### PR TITLE
Fix the property read-back when setting a property

### DIFF
--- a/libgstd/gstd_iformatter.c
+++ b/libgstd/gstd_iformatter.c
@@ -66,6 +66,13 @@ gstd_iformatter_set_string_value (GstdIFormatter * self, const gchar * value)
 }
 
 void
+gstd_iformatter_set_null_value (GstdIFormatter * self)
+{
+  g_return_if_fail (self);
+  GSTD_IFORMATTER_GET_INTERFACE (self)->set_null_value (self);
+}
+
+void
 gstd_iformatter_set_value (GstdIFormatter * self, const GValue * value)
 {
   g_return_if_fail (self);

--- a/libgstd/gstd_iformatter.h
+++ b/libgstd/gstd_iformatter.h
@@ -25,13 +25,11 @@
 #include "gstd_object.h"
 
 G_BEGIN_DECLS
-
 #define GSTD_TYPE_IFORMATTER                (gstd_iformatter_get_type ())
 #define GSTD_IFORMATTER(obj)                (G_TYPE_CHECK_INSTANCE_CAST ((obj), GSTD_TYPE_IFORMATTER, GstdIFormatter))
 #define GSTD_IS_IFORMATTER(obj)             (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GSTD_TYPE_IFORMATTER))
 #define GSTD_IFORMATTER_GET_INTERFACE(inst) (G_TYPE_INSTANCE_GET_INTERFACE ((inst), GSTD_TYPE_IFORMATTER, GstdIFormatterInterface))
-
-GType gstd_iformatter_get_type (void);
+    GType gstd_iformatter_get_type (void);
 
 typedef struct _GstdIFormatter GstdIFormatter;
 typedef struct _GstdIFormatterInterface GstdIFormatterInterface;
@@ -52,6 +50,8 @@ struct _GstdIFormatterInterface
 
   void (*set_string_value) (GstdIFormatter * self, const gchar * value);
 
+  void (*set_null_value) (GstdIFormatter * self);
+
   void (*set_value) (GstdIFormatter * self, const GValue * value);
 
   void (*generate) (GstdIFormatter * self, gchar ** outstring);
@@ -71,10 +71,11 @@ void gstd_iformatter_set_member_name (GstdIFormatter * self,
 void gstd_iformatter_set_string_value (GstdIFormatter * self,
     const gchar * value);
 
+void gstd_iformatter_set_null_value (GstdIFormatter * self);
+
 void gstd_iformatter_set_value (GstdIFormatter * self, const GValue * value);
 
 void gstd_iformatter_generate (GstdIFormatter * self, gchar ** outstring);
 
 G_END_DECLS
-
 #endif /* __GSTD_IFORMATTER_H__ */

--- a/libgstd/gstd_json_builder.c
+++ b/libgstd/gstd_json_builder.c
@@ -144,10 +144,13 @@ gstd_json_set_string_value (GstdIFormatter * iface, const gchar * value)
   GstdJsonBuilder *self;
 
   g_return_if_fail (GSTD_IS_JSON_BUILDER (iface));
-  g_return_if_fail (value);
 
   self = GSTD_JSON_BUILDER (iface);
-  json_builder_add_string_value (self->json_builder, value);
+  if (value) {
+    json_builder_add_string_value (self->json_builder, value);
+  } else {
+    json_builder_add_string_value (self->json_builder, "");
+  }
 }
 
 static void

--- a/libgstd/gstd_json_builder.c
+++ b/libgstd/gstd_json_builder.c
@@ -151,6 +151,17 @@ gstd_json_set_string_value (GstdIFormatter * iface, const gchar * value)
 }
 
 static void
+gstd_json_set_null_value (GstdIFormatter * iface)
+{
+  GstdJsonBuilder *self;
+
+  g_return_if_fail (GSTD_IS_JSON_BUILDER (iface));
+
+  self = GSTD_JSON_BUILDER (iface);
+  json_builder_add_null_value (self->json_builder);
+}
+
+static void
 gstd_json_set_value (GstdIFormatter * iface, const GValue * value)
 {
   GstdJsonBuilder *self;
@@ -266,6 +277,7 @@ gstd_iformatter_interface_init (GstdIFormatterInterface * iface)
   iface->end_array = gstd_json_builder_end_array;
   iface->set_member_name = gstd_json_set_member_name;
   iface->set_string_value = gstd_json_set_string_value;
+  iface->set_null_value = gstd_json_set_null_value;
   iface->set_value = gstd_json_set_value;
   iface->generate = gstd_json_builder_generate;
 }

--- a/libgstd/gstd_property.c
+++ b/libgstd/gstd_property.c
@@ -205,15 +205,17 @@ gstd_property_to_string (GstdObject * obj, gchar ** outstring)
   gstd_iformatter_set_member_name (formatter, "name");
   gstd_iformatter_set_string_value (formatter, property->name);
 
-  gstd_iformatter_set_member_name (formatter, "value");
+  if (property->flags & G_PARAM_READABLE) {
+    gstd_iformatter_set_member_name (formatter, "value");
 
-  g_value_init (&value, property->value_type);
-  g_object_get_property (G_OBJECT (self->target), property->name, &value);
+    g_value_init (&value, property->value_type);
+    g_object_get_property (G_OBJECT (self->target), property->name, &value);
 
-  g_assert (klass->add_value);
-  klass->add_value (self, formatter, &value);
+    g_assert (klass->add_value);
+    klass->add_value (self, formatter, &value);
 
-  g_value_unset (&value);
+    g_value_unset (&value);
+  }
 
   gstd_iformatter_set_member_name (formatter, "param");
   /* Describe the parameter specs using a structure */

--- a/libgstd/gstd_property.c
+++ b/libgstd/gstd_property.c
@@ -215,6 +215,9 @@ gstd_property_to_string (GstdObject * obj, gchar ** outstring)
     klass->add_value (self, formatter, &value);
 
     g_value_unset (&value);
+  } else {
+    gstd_iformatter_set_member_name (formatter, "value");
+    gstd_iformatter_set_null_value (formatter);
   }
 
   gstd_iformatter_set_member_name (formatter, "param");


### PR DESCRIPTION
This fixes a bug that issues critical warnings when dealing with write-only properties. When setting this kind of property many times, the number of messages gets unmanageable, and the logs get dirty

Addressing: https://github.com/RidgeRun/gstd-1.x/issues/275, https://github.com/RidgeRun/gstd-1.x/issues/313