### PR TITLE
Hotfix/fix subproject support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl required version of autoconf
 AC_PREREQ([2.53])
 
 dnl Gstreamer's daemon package name and version
-AC_INIT([gstd],[0.15.0])
+AC_INIT([gstd],[0.15.1])
 
 dnl required version of gstreamer and gst-plugins-base
 GST_REQUIRED=1.0.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ gstd (0.15.1-1) unstable; urgency=medium
 
   * Add includes to the declaration of the dependency
 
- -- RidgeRun Engineering <support@ridgerun.com>  Wed, 24 May 2022 20:28:00  +0200
+ -- RidgeRun Engineering <support@ridgerun.com>  Wed, 24 May 2023 20:28:00 +0200
 
 gstd (0.15.0-1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gstd (0.15.1-1) unstable; urgency=medium
+
+  * Add includes to the declaration of the dependency
+
+ -- RidgeRun Engineering <support@ridgerun.com>  Wed, 24 May 2022 20:28:00  +0200
+
 gstd (0.15.0-1) unstable; urgency=medium
 
   * Change project license to LGPL2+

--- a/libgstc/c/meson.build
+++ b/libgstc/c/meson.build
@@ -33,7 +33,8 @@ install_headers('libgstc.h')
 pkgconfig.generate(gstc_lib, description : 'GStreamer Client library to control Gstd')
 
 # Define the library as an internal dependency to the current build
+lib_gstc_inc = include_directories('.')
 lib_gstc_dep = declare_dependency(link_with: gstc_lib,
-  dependencies : [libgstc_deps])
+  dependencies : [libgstc_deps], include_directories : [lib_gstc_inc])
 
 lib_gstc_dir = meson.current_source_dir()

--- a/libgstc/c/meson.build
+++ b/libgstc/c/meson.build
@@ -34,7 +34,10 @@ pkgconfig.generate(gstc_lib, description : 'GStreamer Client library to control 
 
 # Define the library as an internal dependency to the current build
 lib_gstc_inc = include_directories('.')
-lib_gstc_dep = declare_dependency(link_with: gstc_lib,
-  dependencies : [libgstc_deps], include_directories : [lib_gstc_inc])
+lib_gstc_dep = declare_dependency(
+  link_with: gstc_lib,
+  dependencies : [libgstc_deps],
+  include_directories : [lib_gstc_inc]
+)
 
 lib_gstc_dir = meson.current_source_dir()

--- a/libgstd/meson.build
+++ b/libgstd/meson.build
@@ -82,5 +82,8 @@ pkgconfig.generate(gstd_lib_manager, description : 'GStreamer Manager library to
 
 # Define the library as an internal dependency to the current build
 lib_gstd_inc = include_directories('.')
-lib_gstd_dep = declare_dependency(link_with: gstd_lib_manager,
-  dependencies : [libgstd_deps], include_directories : [lib_gstd_inc])
+lib_gstd_dep = declare_dependency(
+  link_with: gstd_lib_manager,
+  dependencies : [libgstd_deps],
+  include_directories : [lib_gstd_inc]
+)

--- a/libgstd/meson.build
+++ b/libgstd/meson.build
@@ -81,5 +81,6 @@ install_headers(gstd_headers)
 pkgconfig.generate(gstd_lib_manager, description : 'GStreamer Manager library to control Gstd')
 
 # Define the library as an internal dependency to the current build
+lib_gstd_inc = include_directories('.')
 lib_gstd_dep = declare_dependency(link_with: gstd_lib_manager,
-  dependencies : [libgstd_deps])
+  dependencies : [libgstd_deps], include_directories : [lib_gstd_inc])

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('gstd', 'c',
-  version : '0.15.0',
+  version : '0.15.1',
   meson_version : '>= 0.50',
   default_options : [
     'c_std=c11',


### PR DESCRIPTION
This hotfix:

* Fixes the include paths into the dependencies to allow projects that use GstD as a subproject to find the includes for LibGstC and LibGstD