### PR TITLE
Fix python folder name error when running debuild

### DIFF
--- a/debian/pygstc.install
+++ b/debian/pygstc.install
@@ -1,1 +1,1 @@
-debian/tmp/usr/lib/python3/*
+debian/tmp/usr/lib/python*


### PR DESCRIPTION
The Debian install script for the Python client was searching for a directory named `python3`, but on certain systems, it might be labeled as `python3.8`, `python3.9`, etc., leading to an error.