### PR TITLE
Remove Ubuntu 18.04 form GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
         include:
           - os: ubuntu-22.04
@@ -55,7 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
         include:
           - os: ubuntu-22.04
@@ -76,11 +74,7 @@ jobs:
         sudo apt install ninja-build python3-wheel
         sudo pip3 install meson
 
-    - name: Generate for Ubuntu 18.04
-      if: ${{ matrix.os == 'ubuntu-18.04' }}
-      run: meson --werror build -Dpython.purelibdir=/usr/lib/python3/dist-packages/
     - name: Generate for Ubuntu 20.04 and above
-      if: ${{ matrix.os != 'ubuntu-18.04' }}
       run: meson --werror build -Dpython.install_env=auto
     - name: Compile
       run: ninja -C build


### PR DESCRIPTION
The GitHub runner for Ubuntu 18.04 was [removed on 12/1/22](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)
