### PR TITLE
Feature/add support for actions with arguments

### DIFF
--- a/libgstd/gstd_action.c
+++ b/libgstd/gstd_action.c
@@ -209,6 +209,8 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
   GSignalQuery query;
   guint action_id;
   gint ret_sig = 0;
+  GValue *args = NULL;
+  gchar **arg_list = NULL;
 
   GST_INFO_OBJECT (action, "Action create");
 
@@ -222,19 +224,71 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
       G_OBJECT_TYPE (action->target));
   g_signal_query (action_id, &query);
 
-  if (query.n_params > 0) {
-    GST_ERROR_OBJECT (action, "Only actions with no parameters are supported");
-    ret = GSTD_BAD_VALUE;
-    goto out;
+  GST_ERROR_OBJECT (action, "description: %s", description);
+
+  // You must parse description into arg_list[] matching query.n_params
+  arg_list = g_strsplit (description, " ", query.n_params + 1);
+  if (!arg_list) {
+    GST_ERROR_OBJECT (action, "!arg_list");
+    return GSTD_BAD_VALUE;
   }
 
-  GST_INFO_OBJECT (action, "Emit to %s", GST_OBJECT_NAME (action->target));
-  g_signal_emit_by_name (action->target, name, &ret_sig);
+  args = g_new0 (GValue, query.n_params + 2);
 
-  if (ret_sig != 0) {
-    ret = GSTD_BAD_VALUE;
+  g_value_init (&args[0], G_TYPE_OBJECT);
+  g_value_set_object (&args[0], action->target);
+
+  for (guint i = 1; i <= query.n_params; i++) {
+    g_value_init (&args[i], query.param_types[i]);
+
+    GST_ERROR_OBJECT (action, "param_type: %s",
+        g_type_name (query.param_types[0]));
+
+    if (query.param_types[i - 1] == G_TYPE_STRING) {
+      g_value_set_string (&args[i], arg_list[i]);
+    } else if (query.param_types[i - 1] == G_TYPE_INT) {
+      g_value_set_int (&args[i], atoi (arg_list[i]));
+    } else if (query.param_types[i - 1] == G_TYPE_UINT) {
+      g_value_set_uint (&args[i], (guint) atoi (arg_list[i]));
+    } else if (query.param_types[i - 1] == G_TYPE_UINT64) {
+      g_value_set_uint64 (&args[i], (guint64) g_ascii_strtoull (arg_list[i],
+              NULL, 10));
+      GST_ERROR_OBJECT (action, "arg_list[i+1]: %s", arg_list[i]);
+      GST_ERROR_OBJECT (action, "value: %ld", g_value_get_uint64 (&args[i]));
+    } else if (query.param_types[i - 1] == G_TYPE_BOOLEAN) {
+      g_value_set_boolean (&args[i], g_strcmp0 (arg_list[i], "true") == 0);
+    } else if (query.param_types[i - 1] == G_TYPE_FLOAT) {
+      g_value_set_float (&args[i], g_ascii_strtod (arg_list[i], NULL));
+    } else if (query.param_types[i - 1] == G_TYPE_DOUBLE) {
+      g_value_set_double (&args[i], g_ascii_strtod (arg_list[i], NULL));
+    } else {
+      ret = GSTD_BAD_VALUE;
+      goto out;
+    }
   }
+
+  // Set return value container as G_TYPE_INT, stored in ret_sig
+  g_value_init (&args[query.n_params], G_TYPE_INT);
+
+  GST_ERROR_OBJECT (action, "Emit to %s", GST_OBJECT_NAME (action->target));
+  GST_ERROR_OBJECT (action, "description: %s", description);
+  GST_ERROR_OBJECT (action, "name: %s", name);
+  GST_ERROR_OBJECT (action, "n_params: %d", query.n_params);
+  GST_ERROR_OBJECT (action, "object name(action): %s",
+      GSTD_OBJECT_NAME (action));
+
+  g_signal_emitv (args, action_id, 0, &args[query.n_params]);
+
+  ret_sig = g_value_get_int (&args[query.n_params]);
+
+  if (ret_sig != 0)
+    ret = GSTD_BAD_VALUE;
 
 out:
+  for (guint i = 0; i <= query.n_params; i++)
+    g_value_unset (&args[i]);
+  g_free (args);
+  g_strfreev (arg_list);
+
   return ret;
 }

--- a/libgstd/gstd_action.c
+++ b/libgstd/gstd_action.c
@@ -242,9 +242,9 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
     if (query.param_types[i] == G_TYPE_STRING) {
       g_value_set_string (&args[i + 1], arg_list[i]);
     } else if (query.param_types[i] == G_TYPE_INT) {
-      g_value_set_int (&args[i + 1], atoi (arg_list[i]));
+      g_value_set_int (&args[i + 1], g_ascii_strtoll (arg_list[i], NULL, 10));
     } else if (query.param_types[i] == G_TYPE_UINT) {
-      g_value_set_uint (&args[i + 1], (guint) atoi (arg_list[i]));
+      g_value_set_uint (&args[i + 1], (guint) g_ascii_strtoull (arg_list[i], NULL, 10));
     } else if (query.param_types[i] == G_TYPE_UINT64) {
       g_value_set_uint64 (&args[i + 1], (guint64) g_ascii_strtoull (arg_list[i],
               NULL, 10));

--- a/libgstd/gstd_action.c
+++ b/libgstd/gstd_action.c
@@ -224,10 +224,11 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
       G_OBJECT_TYPE (action->target));
   g_signal_query (action_id, &query);
 
-  arg_list = g_strsplit (description, " ", query.n_params);
-  if (!arg_list) {
+  if (query.n_params > 0 && g_strcmp0(description, "(null)") == 0) {
     return GSTD_BAD_VALUE;
   }
+
+  arg_list = g_strsplit (description, " ", query.n_params);
 
   /* One additional value to store the instance as first value */
   args = g_new0 (GValue, query.n_params + 1);

--- a/libgstd/gstd_action.c
+++ b/libgstd/gstd_action.c
@@ -230,6 +230,10 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
     arg_list = g_strsplit (description, " ", query.n_params);
   }
 
+  if (g_strv_length (arg_list) != query.n_params) {
+    return GSTD_NULL_ARGUMENT;
+  }
+
   /* One additional value to store the instance as first value */
   args = g_new0 (GValue, query.n_params + 1);
 

--- a/libgstd/gstd_action.c
+++ b/libgstd/gstd_action.c
@@ -224,11 +224,11 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
       G_OBJECT_TYPE (action->target));
   g_signal_query (action_id, &query);
 
-  if (query.n_params > 0 && g_strcmp0(description, "(null)") == 0) {
-    return GSTD_BAD_VALUE;
+  if (query.n_params > 0 && (!description || g_strcmp0(description, "(null)") == 0 || g_strcmp0(description, "") == 0)) {
+    return GSTD_NULL_ARGUMENT;
+  } else if (description) {
+    arg_list = g_strsplit (description, " ", query.n_params);
   }
-
-  arg_list = g_strsplit (description, " ", query.n_params);
 
   /* One additional value to store the instance as first value */
   args = g_new0 (GValue, query.n_params + 1);
@@ -255,7 +255,7 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
     } else if (query.param_types[i] == G_TYPE_DOUBLE) {
       g_value_set_double (&args[i + 1], g_ascii_strtod (arg_list[i], NULL));
     } else {
-      ret = GSTD_BAD_VALUE;
+      ret = GSTD_BAD_COMMAND;
       goto out;
     }
   }

--- a/libgstd/gstd_action.c
+++ b/libgstd/gstd_action.c
@@ -224,7 +224,7 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
       G_OBJECT_TYPE (action->target));
   g_signal_query (action_id, &query);
 
-  arg_list = g_strsplit (description, " ", query.n_params + 1);
+  arg_list = g_strsplit (description, " ", query.n_params);
   if (!arg_list) {
     return GSTD_BAD_VALUE;
   }
@@ -235,24 +235,24 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
   g_value_init (&args[0], G_TYPE_OBJECT);
   g_value_set_object (&args[0], action->target);
 
-  for (guint i = 1; i <= query.n_params; i++) {
-    g_value_init (&args[i], query.param_types[i - 1]);
+  for (guint i = 0; i < query.n_params; i++) {
+    g_value_init (&args[i + 1], query.param_types[i]);
 
-    if (query.param_types[i - 1] == G_TYPE_STRING) {
-      g_value_set_string (&args[i], arg_list[i]);
-    } else if (query.param_types[i - 1] == G_TYPE_INT) {
-      g_value_set_int (&args[i], atoi (arg_list[i]));
-    } else if (query.param_types[i - 1] == G_TYPE_UINT) {
-      g_value_set_uint (&args[i], (guint) atoi (arg_list[i]));
-    } else if (query.param_types[i - 1] == G_TYPE_UINT64) {
-      g_value_set_uint64 (&args[i], (guint64) g_ascii_strtoull (arg_list[i],
+    if (query.param_types[i] == G_TYPE_STRING) {
+      g_value_set_string (&args[i + 1], arg_list[i]);
+    } else if (query.param_types[i] == G_TYPE_INT) {
+      g_value_set_int (&args[i + 1], atoi (arg_list[i]));
+    } else if (query.param_types[i] == G_TYPE_UINT) {
+      g_value_set_uint (&args[i + 1], (guint) atoi (arg_list[i]));
+    } else if (query.param_types[i] == G_TYPE_UINT64) {
+      g_value_set_uint64 (&args[i + 1], (guint64) g_ascii_strtoull (arg_list[i],
               NULL, 10));
-    } else if (query.param_types[i - 1] == G_TYPE_BOOLEAN) {
-      g_value_set_boolean (&args[i], g_strcmp0 (arg_list[i], "true") == 0);
-    } else if (query.param_types[i - 1] == G_TYPE_FLOAT) {
-      g_value_set_float (&args[i], g_ascii_strtod (arg_list[i], NULL));
-    } else if (query.param_types[i - 1] == G_TYPE_DOUBLE) {
-      g_value_set_double (&args[i], g_ascii_strtod (arg_list[i], NULL));
+    } else if (query.param_types[i] == G_TYPE_BOOLEAN) {
+      g_value_set_boolean (&args[i + 1], g_strcmp0 (arg_list[i], "true") == 0);
+    } else if (query.param_types[i] == G_TYPE_FLOAT) {
+      g_value_set_float (&args[i + 1], g_ascii_strtod (arg_list[i], NULL));
+    } else if (query.param_types[i] == G_TYPE_DOUBLE) {
+      g_value_set_double (&args[i + 1], g_ascii_strtod (arg_list[i], NULL));
     } else {
       ret = GSTD_BAD_VALUE;
       goto out;

--- a/libgstd/gstd_action.c
+++ b/libgstd/gstd_action.c
@@ -249,7 +249,7 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
       g_value_set_uint64 (&args[i + 1], (guint64) g_ascii_strtoull (arg_list[i],
               NULL, 10));
     } else if (query.param_types[i] == G_TYPE_BOOLEAN) {
-      g_value_set_boolean (&args[i + 1], g_strcmp0 (arg_list[i], "true") == 0);
+      g_value_set_boolean (&args[i + 1], g_ascii_strcasecmp (arg_list[i], "true") == 0);
     } else if (query.param_types[i] == G_TYPE_FLOAT) {
       g_value_set_float (&args[i + 1], g_ascii_strtod (arg_list[i], NULL));
     } else if (query.param_types[i] == G_TYPE_DOUBLE) {
@@ -264,7 +264,7 @@ gstd_action_create_default (GstdObject * object, const gchar * name,
     g_value_init(&ret_sig, query.return_type);
     g_signal_emitv (args, action_id, 0, &ret_sig);
 
-    /* TODO: Use ret_sig value */
+    /* The return value is not required */
 
     g_value_unset(&ret_sig);
   } else {

--- a/libgstd/gstd_http.c
+++ b/libgstd/gstd_http.c
@@ -176,8 +176,6 @@ do_get (SoupServer * server, SoupMessage * msg, char **output, const char *path,
   gchar *message = NULL;
   GstdReturnCode ret = GSTD_EOK;
 
-  GST_ERROR_OBJECT (session, "path value %s", path);
-
   g_return_val_if_fail (server, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (msg, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (session, GSTD_NULL_ARGUMENT);
@@ -198,9 +196,6 @@ do_post (SoupServer * server, SoupMessage * msg, char *name,
 {
   gchar *message = NULL;
   GstdReturnCode ret = GSTD_EOK;
-
-  GST_ERROR_OBJECT (session, "path value on post %s", path);
-  GST_ERROR_OBJECT (session, "name value on post %s", name);
 
   g_return_val_if_fail (server, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (msg, GSTD_NULL_ARGUMENT);
@@ -240,7 +235,6 @@ do_put (SoupServer * server, SoupMessage * msg, char *name, char **output,
   g_return_val_if_fail (server, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (msg, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (session, GSTD_NULL_ARGUMENT);
-  GST_ERROR_OBJECT (session, "name value %s", name);
   g_return_val_if_fail (name, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (output, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (path, GSTD_NULL_ARGUMENT);

--- a/libgstd/gstd_http.c
+++ b/libgstd/gstd_http.c
@@ -374,6 +374,10 @@ parse_json_body (SoupMessage *msg, gchar **out_name, gchar **out_desc)
   JsonNode *root = NULL;
   GError *err = NULL;
 
+  g_return_if_fail (msg);
+  g_return_if_fail (out_name);
+  g_return_if_fail (out_desc);
+
   *out_name = NULL;
   *out_desc = NULL;
 

--- a/libgstd/gstd_http.c
+++ b/libgstd/gstd_http.c
@@ -382,12 +382,14 @@ parse_json_body (SoupMessage *msg, gchar **out_name, gchar **out_desc)
   *out_desc = NULL;
 
   soup_message_body_flatten (msg->request_body);
-  if (!msg->request_body || msg->request_body->length == 0)
+  if (!msg->request_body || msg->request_body->length == 0) {
     return;
+  }
 
   content_type = soup_message_headers_get_content_type (msg->request_headers, NULL);
-  if (!content_type || !g_str_has_prefix (content_type, "application/json"))
+  if (!content_type || !g_str_has_prefix (content_type, "application/json")) {
     return;
+  }
 
   parser = json_parser_new ();
   if (!json_parser_load_from_data (parser,

--- a/libgstd/gstd_http.c
+++ b/libgstd/gstd_http.c
@@ -333,6 +333,10 @@ do_request (gpointer data_request, gpointer eval)
   } else if (msg->method == SOUP_METHOD_OPTIONS) {
     ret = GSTD_EOK;
   }
+  g_free (name);
+  g_free (description_pipe);
+  name = NULL;
+  description_pipe = NULL;
 
   description = gstd_return_code_to_string (ret);
   response =

--- a/libgstd/gstd_parser.c
+++ b/libgstd/gstd_parser.c
@@ -939,13 +939,13 @@ gstd_parser_action_emit (GstdSession * session, gchar * action,
   g_return_val_if_fail (args, GSTD_NULL_ARGUMENT);
   g_return_val_if_fail (response, GSTD_NULL_ARGUMENT);
 
-  tokens = g_strsplit (args, " ", 3);
+  tokens = g_strsplit (args, " ", 4);
   check_argument (tokens[0], GSTD_BAD_COMMAND);
   check_argument (tokens[1], GSTD_BAD_COMMAND);
   check_argument (tokens[2], GSTD_BAD_COMMAND);
 
-  uri = g_strdup_printf ("/pipelines/%s/elements/%s/actions/%s %s",
-      tokens[0], tokens[1], tokens[2], tokens[2]);
+  uri = g_strdup_printf ("/pipelines/%s/elements/%s/actions/%s %s %s",
+      tokens[0], tokens[1], tokens[2], tokens[2], tokens[3]);
   ret = gstd_parser_parse_raw_cmd (session, (gchar *) "create", uri, response);
 
   g_free (uri);


### PR DESCRIPTION
Support action signals with one or more arguments.

Support adding `name` and `description` to HTTP PUT and POST requests in the request body as `application/json` type